### PR TITLE
Setup filter macro parameter and added open project livedata filter configuration

### DIFF
--- a/project-management-livedata/src/main/resources/projectManagementLiveDataConfiguration.json
+++ b/project-management-livedata/src/main/resources/projectManagementLiveDataConfiguration.json
@@ -14,7 +14,6 @@
         "id": "identifier.value",
         "type": "String",
         "name": "Identifier",
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "identifier.location"
@@ -24,14 +23,12 @@
         "id": "type",
         "type": "String",
         "name": "Type",
-        "editable": false,
         "displayer": "html"
       },
       {
         "id": "summary.value",
         "type": "String",
         "name": "Summary",
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "summary.location"
@@ -41,53 +38,38 @@
         "id": "description",
         "type": "String",
         "name": "description",
-        "editable": false,
         "displayer": "text"
       },
       {
         "id": "startDate",
         "type": "Date",
-        "name": "Start Date",
-        "editable": false
+        "name": "Start Date"
       },
       {
         "id": "dueDate",
         "type": "Date",
-        "name": "Due Date",
-        "editable": false
+        "name": "Due Date"
       },
       {
         "id": "progress",
         "type": "String",
         "name": "Progress",
-        "sortable": true,
-        "filterable": true,
-        "editable": true,
         "displayer": "number"
       },
       {
         "id": "creationDate",
         "type": "Date",
-        "name": "Creation Date",
-        "sortable": true,
-        "filterable": true,
-        "editable": false
+        "name": "Creation Date"
       },
       {
         "id": "updateDate",
         "type": "Date",
-        "name": "Update Date",
-        "sortable": true,
-        "filterable": true,
-        "editable": false
+        "name": "Update Date"
       },
       {
         "id": "creator.value",
         "type": "String",
         "name": "Creator",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "creator.location"
@@ -97,27 +79,18 @@
         "id": "assignees",
         "type": "String",
         "name": "Assignee(s)",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": "html"
       },
       {
         "id": "priority",
         "type": "String",
         "name": "Priority",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": "text"
       },
       {
         "id": "project.value",
         "type": "String",
         "name": "Project",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "project.location"
@@ -127,18 +100,12 @@
         "id": "status",
         "type": "String",
         "name": "Status",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": "text"
       },
       {
         "id": "reporter.value",
         "type": "String",
         "name": "Reporter",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "reporter.location"
@@ -148,9 +115,6 @@
         "id": "resolution",
         "type": "String",
         "name": "Resolution",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": "text"
       },
       {
@@ -162,24 +126,17 @@
         "id": "labels",
         "type": "String",
         "name": "Labels",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": "text"
       },
       {
         "id": "closeDate",
         "type": "Date",
-        "name": "Close Date",
-        "editable": false
+        "name": "Close Date"
       },
       {
         "id": "milestones.value",
         "type": "String",
         "name": "Milestones",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "milestones.location"
@@ -189,9 +146,6 @@
         "id": "closedBy.value",
         "type": "String",
         "name": "Closed By",
-        "sortable": true,
-        "filterable": true,
-        "editable": false,
         "displayer": {
           "id": "link",
           "propertyHref": "closedBy.location"
@@ -202,8 +156,8 @@
       {
         "id": "Boolean",
         "sortable": true,
-        "filterable": true,
-        "editable": true,
+        "filterable": false,
+        "editable": false,
         "displayer": "boolean",
         "filter": {
           "id": "boolean",
@@ -214,15 +168,15 @@
       {
         "id": "Date",
         "sortable": true,
-        "filterable": true,
-        "editable": true,
+        "filterable": false,
+        "editable": false,
         "displayer": "date",
         "filter": "date"
       },
       {
         "id": "Number",
         "sortable": true,
-        "filterable": true,
+        "filterable": false,
         "editable": true,
         "displayer": "number",
         "filter": "number"
@@ -230,8 +184,8 @@
       {
         "id": "String",
         "sortable": true,
-        "filterable": true,
-        "editable": true,
+        "filterable": false,
+        "editable": false,
         "filter": "text"
       }
     ]

--- a/project-management-macro/src/main/java/org/xwiki/projectmanagement/internal/OpenProjClient.java
+++ b/project-management-macro/src/main/java/org/xwiki/projectmanagement/internal/OpenProjClient.java
@@ -1,0 +1,150 @@
+package org.xwiki.projectmanagement.internal;
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.LiveDataQuery;
+import org.xwiki.rest.XWikiRestComponent;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xwiki.projectmanagement.ProjectManagementClient;
+import com.xwiki.projectmanagement.ProjectManagementClientExecutionContext;
+import com.xwiki.projectmanagement.exception.WorkItemCreationException;
+import com.xwiki.projectmanagement.exception.WorkItemDeletionException;
+import com.xwiki.projectmanagement.exception.WorkItemNotFoundException;
+import com.xwiki.projectmanagement.exception.WorkItemRetrievalException;
+import com.xwiki.projectmanagement.exception.WorkItemUpdatingException;
+import com.xwiki.projectmanagement.internal.DefaultWorkItemsResource;
+import com.xwiki.projectmanagement.model.PaginatedResult;
+import com.xwiki.projectmanagement.model.WorkItem;
+
+/**
+ * Test client retrieving entries from local files and other sources.
+ *
+ * @version $Id$
+ */
+@Component
+@Named("openproject")
+@Singleton
+public class OpenProjClient implements ProjectManagementClient
+{
+    // For testing. REMOVE
+    @Inject
+    @Named("com.xwiki.projectmanagement.internal.DefaultWorkItemsResource")
+    private XWikiRestComponent workItemsResource;
+
+    @Inject
+    private ProjectManagementClientExecutionContext executionContext;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public WorkItem getWorkItem(String workItemId) throws WorkItemNotFoundException
+    {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public PaginatedResult<WorkItem> getWorkItems(int page, int pageSize, List<LiveDataQuery.Filter> filters)
+        throws WorkItemRetrievalException
+    {
+        Map<String, Object> map = executionContext.getContext();
+
+        executionContext.getContext();
+        PaginatedResult<WorkItem> result = new PaginatedResult<>();
+        // GET ENTRIES FROM RESOURCE ---------------
+        try {
+
+            PaginatedResult<WorkItem> paginatedResult =
+                (PaginatedResult<WorkItem>) ((DefaultWorkItemsResource) workItemsResource).getWorkItems("wiki",
+                    "smth",
+                    0, 10).getEntity();
+            result.getItems().addAll(paginatedResult.getItems());
+        } catch (Exception e) {
+
+        }
+
+        // GET ENTRIES FROM TEST FILE --------------
+        Map<String, WorkItem> newDb = maybeGetTestEntries();
+        if (newDb != null) {
+            List<WorkItem> workItems = new ArrayList<>(newDb.values());
+            result.getItems().addAll(workItems);
+        }
+
+        return result;
+    }
+
+    @Override
+    public WorkItem createWorkItem(WorkItem workItem) throws WorkItemCreationException
+    {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public WorkItem updateWorkItem(WorkItem workItem) throws WorkItemUpdatingException
+    {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean deleteWorkItem(String workItemId) throws WorkItemDeletionException
+    {
+        return false;
+    }
+
+    private static Map<String, WorkItem> maybeGetTestEntries()
+    {
+        String testPath = "/home/teo/Desktop/customLiveDataStore.json";
+        File testFile = new File(testPath);
+        String foundEntriesJSON = "";
+        Map<String, WorkItem> newDb = null;
+        if (testFile.exists()) {
+            try (InputStream testFileInputStream = new FileInputStream(testFile)) {
+                foundEntriesJSON = IOUtils.toString(testFileInputStream, Charset.defaultCharset());
+
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode root = objectMapper.readTree(foundEntriesJSON);
+                newDb = objectMapper.readerFor(new TypeReference<Map<String, WorkItem>>()
+                {
+                }).readValue(root);
+            } catch (Exception e) {
+            }
+        }
+        return newDb;
+    }
+}

--- a/project-management-macro/src/main/java/org/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
+++ b/project-management-macro/src/main/java/org/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
@@ -106,10 +106,15 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
                     .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
             ((DefaultProjectManagementClientExecutionContext) projectManagementMacroContext).setContext(clientContext);
         }
+        String newContent = content;
+        if (parameters.getFilters() != null && !parameters.getFilters().isEmpty()) {
+            newContent = parameters.getFilters();
+            parameters.setFilters("");
+        }
         try {
             Macro<T> displayerMacro = componentManager.getInstance(Macro.class, displayer.toString());
 
-            return displayerMacro.execute(parameters, content, context);
+            return displayerMacro.execute(parameters, newContent, context);
         } catch (ComponentLookupException e) {
             throw new MacroExecutionException(String.format("Could not find the displayer [%s].", displayer.name()), e);
         }

--- a/project-management-macro/src/main/resources/META-INF/components.txt
+++ b/project-management-macro/src/main/resources/META-INF/components.txt
@@ -1,3 +1,4 @@
 org.xwiki.projectmanagement.internal.macro.TestMacro
 org.xwiki.projectmanagement.internal.displayers.WorkItemsCardsDisplayer
 org.xwiki.projectmanagement.internal.displayers.WorkItemsListDisplayer
+org.xwiki.projectmanagement.internal.OpenProjClient

--- a/project-management-macro/src/main/resources/css/projectmanagement/filterBuilder.css
+++ b/project-management-macro/src/main/resources/css/projectmanagement/filterBuilder.css
@@ -21,13 +21,20 @@
   display: flex;
   justify-content: space-between;
   gap: 1em;
-  align-items: center;
 }
 
 .projManagConstraint > div {
   flex-grow: 1;
 }
 
-.projManagConstraint .projManagConstraintValue {
+.projManagConstraintName, .projManagConstraintValueContainer > input,.projManagConstraintOperator {
+  width: 100%;
+}
+
+.projManagContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1em;
   width: 100%;
 }

--- a/project-management-macro/src/main/resources/js/projectmanagement/filterBuilder.js
+++ b/project-management-macro/src/main/resources/js/projectmanagement/filterBuilder.js
@@ -17,57 +17,166 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-define('project-management-filter-builder', ['jquery', 'xwiki-selectize'], function($) {
+define('project-management-filter-builder', ['jquery', 'xwiki-selectize'], function ($) {
   let constraintBuilder = $('.projManagementConstraintBuilder');
   let addButton = $('.projManagementConstraintBuilder #addConstraint');
   let template = $('#projManagConstraintTemplate');
   let addPoint = $('.projManagConstraints');
-  let getJson = function() {
+  let cfg = constraintBuilder.data('cfg');
+  let defaultDisplayer = function (type, inputElem, operator, params) {
+    let parent = inputElem.parent();
+    parent.children().remove();
+    parent.append(inputElem);
+    inputElem.removeClass('hidden');
+    switch (type) {
+      case "number":
+        inputElem.attr('type', 'number');
+        break;
+      case "date":
+        inputElem.attr('type', 'date');
+        break;
+      case "list":
+        inputElem.addClass('hidden');
+        inputElem.attr('type', 'text');
+        let listItem = $('<input />').addClass('listItem');
+        let listItemType = (params && params.type) || 'text';
+        listItem.attr('type',  listItemType)
+        parent.append(listItem);
+        listItem.on('change', function () {
+          let valElemValue = parent.find('.listItem').map((i, e) => $(e).val()).filter(v => v !== '').get().join('|');
+          inputElem.val(valElemValue);
+          inputElem.trigger('change');
+        });
+        let addItemButton = $('<div></div>').append($('<span></span>').addClass('fa').addClass('fa-plus'));
+        parent.append(addItemButton);
+        if (inputElem.val() != '') {
+          let vals = inputElem.val().split('|');
+          for (let i = 0; i < vals.length; i++) {
+            if (i == 0) {
+              listItem.val(vals[i]);
+            } else {
+              listItem.clone(true).val(vals[i]).insertBefore(addItemButton);
+            }
+          }
+        }
+        addItemButton.on('click', function() {
+          listItem.clone(true).val('').insertBefore(addItemButton);
+        });
+        break;
+      case "boolean":
+        //inputElem.xwikiSelectize();
+        inputElem.attr('type', 'text');
+        break;
+      default: // text
+        inputElem.attr('type', 'text');
+
+        break;
+    }
+  };
+  let getJson = function () {
     let resultJson = {};
     constraintBuilder.find('.projManagConstraint').each(function (index, constraint) {
       let root = $(constraint);
       let key = $(root.find('select.projManagConstraintName'));
+      let operator = $(root.find('select.projManagConstraintOperator'))
       let val = $(root.find('input.projManagConstraintValue'));
       if (!val.val()) {
         return;
       }
-      if (resultJson[key.val()] && resultJson[key.val()].push) {
-        resultJson[key.val()].push(val.val())
-      } else {
-        resultJson[key.val()] = [val.val()];
-      }
+      let filter = resultJson[key.val()] || { property: key.val(), constraints: []};
+      filter.constraints.push({operator: operator.val(), value: val.val()});
+      resultJson[key.val()] = filter;
     });
     return resultJson;
   };
-  let addFilter = function (key, value) {
+  let addFilter = function (filter) {
     // Clone template and add it to dom.
     let newConstraint = template.clone();
     newConstraint.removeAttr('id');
     newConstraint.removeClass('hidden');
     addPoint.append(newConstraint);
-    if (key && value) {
-      newConstraint.find('select.projManagConstraintName').val(key);
-      newConstraint.find('.projManagConstraintValue').val(value);
-    }
-    newConstraint.find('select').xwikiSelectize({});
-    newConstraint.find('input.projManagConstraintValue').on('change', function(e) {
-      constraintBuilder.trigger('constraintsUpdated', [getJson()]);
+    //newConstraint.find('select').xwikiSelectize({});
+    // Handle the operator field. It should change the value field depending on the type.
+    newConstraint.find('select.projManagConstraintOperator').on('change', function (e, initFilter) {
+      let operatorElem = $(e.target);
+      let parent = operatorElem.closest('.projManagConstraint');
+      let nameElem = parent.find('.projManagConstraintName');
+      let valElem = parent.find('.projManagConstraintValue');
+      let property = cfg.find(i => i.id == nameElem.val());
+      if (initFilter) {
+        operatorElem.val(initFilter.constraints[0].operator)
+      }
+      // If the operator does not have a value defined, it means it doesnt need a value.
+      if (property.emptyOperators && property.emptyOperators.filter(o => o.id == operatorElem.val())) {
+        let parent = valElem.parent();
+        parent.children().remove();
+        parent.append(valElem);
+        valElem.hide();
+        return;
+      } else {
+        valElem.show();
+      }
+
+      let valueType = property.filter.id || "text";
+      let displayer = property.valueDisplayer || defaultDisplayer;
+      let displayerParams = property.filter || {};
+      valElem.val('');
+      if (initFilter) {
+        valElem.val(initFilter.constraints[0].value);
+      }
+      displayer(valueType, valElem, operatorElem.val(), displayerParams);
+      valElem.on('change', function (e) {
+        constraintBuilder.trigger('constraintsUpdated', [getJson()]);
+      });
     });
-    // Clear the value input when the field is changed.
-    newConstraint.find('select.projManagConstraintName').on('change', function(e) {
+    // Handle property element change. It should fill the operator element.
+    newConstraint.find('select.projManagConstraintName').on('change', function (e, initFilter) {
       let keyElem = $(e.target);
       let parent = keyElem.closest('.projManagConstraint');
       let valElem = parent.find('.projManagConstraintValue');
-      valElem.clear();
-    });
+      let operatorElem = parent.find('.projManagConstraintOperator');
+      valElem.val('');
+      if (initFilter) {
+      keyElem.val(initFilter.property)}
+      if (!keyElem.val()) {
+        return;
+      }
+      let property = cfg.find(i => i.id == keyElem.val());
+      if (!property) {
+        return;
+      }
+      operatorElem.find('option').remove();
+      property.filter.operators.forEach((operator) => {
+        let option = $('<option></option>').attr('value', operator.id).text(operator.name);
+        operatorElem.append(option);
+      });
+      operatorElem.trigger('change', filter);
+    }).trigger('change', [filter]);
+
+    if (filter) {
+      newConstraint.find('select.projManagConstraintName').val(filter.property).trigger('change');
+      newConstraint.find('.projManagConstraintOperator').val(filter.constraints[0].operator);
+    }
+  };
+  let addDisplayer = function(property, displayer) {
+    let index = cfg.findIndex(i => i.id == property);
+    if (index < 0) {
+      console.error(`Property [${property}] is not part of the builder configuration. Could not set displayer.`);
+      return;
+    }
+    cfg[index].valueDisplayer = displayer;
   };
   addButton.on('click', function (event) {
     event.preventDefault();
     addFilter();
   });
-  return {
+  let builder = {
     getConstraints: getJson,
     element: constraintBuilder,
-    addFilter: addFilter
+    addFilter: addFilter,
+    addDisplayer: addDisplayer,
+    cfg: cfg
   };
+  window.FilterBuilder = builder;
+  return builder;
 });

--- a/project-management-macro/src/main/resources/js/projectmanagement/macro/filterParameter.js
+++ b/project-management-macro/src/main/resources/js/projectmanagement/macro/filterParameter.js
@@ -24,13 +24,20 @@ require.config({
 });
 require(['filterBuilder'], function () {
   require(['jquery', 'project-management-filter-builder'], function($, builder) {
+    console.log('smth');
     builder.element.on('constraintsUpdated', function(e, constraints) {
-      $('#projManagFilter').val($.param(constraints).replaceAll('%5B%5D=', '='));
+      console.log("constraints: " + constraints);
+      let livedataCfg = { query: { filters: [] } };
+      for (key in constraints) {
+        livedataCfg.query.filters.push(constraints[key]);
+      }
+      $('#projManagFilter').val(JSON.stringify(livedataCfg));
     });
     let initBuilder = function (filterString) {
-      const filters = new URLSearchParams(filterString);
-      filters.forEach((value, key) => {
-        builder.addFilter(key, value);
+      const filterCfg = JSON.parse(filterString);
+      let filters = (filterCfg.query && filterCfg.query.filters) || [];
+      filters.forEach((filter) => {
+        builder.addFilter(filter);
       });
     };
     let initialFilter = $('#projManagFilter').val();

--- a/project-management-macro/src/main/resources/templates/filter_builder.vm
+++ b/project-management-macro/src/main/resources/templates/filter_builder.vm
@@ -17,45 +17,55 @@
 ## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
-#macro (livedataProperties_displayOptions $selectedValues)
-  #set ($config = $services.projectmanagementlivedata.getLivedataConfiguration($clientHint))
-  #foreach ($propertyDescriptor in $config.getMeta().getPropertyDescriptors())
-    #set ($discard = $options.add({
-      'name': $propertyDescriptor.id,
-      'value': $propertyDescriptor.name
-    }))
-    <option value="$!escapetool.xml($propertyDescriptor.id)"#if ($selectedValues.contains($propertyDescriptor.id)) selected="selected"#end
-      >$!escapetool.xml($propertyDescriptor.name)</option>
-  #end
-#end
 #macro (filterBuilder $parameters)
 #picker_import
 #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/xwiki.selectize.js', true))
 #set ($discard = $xwiki.ssrx.use('css/projectmanagement/filterBuilder.css'))
 ##set ($discard = $xwiki.jsrx.use('js/projectmanagement/filterBuilder.js'))
-<div class="projManagementConstraintBuilder">
-  <div>
-    <button id="addConstraint" class="btn btn-default">
-      $!escapetool.xml($services.localization.render('projectmanagement.macro.filter.addConstraint'))
-    </button>
-  </div>
-  <div class="projManagConstraints">
-  </div>
-  <div id="projManagConstraintTemplate" class="hidden projManagConstraint">
-    <div>
-      <select class="projManagConstraintName">
-        #livedataProperties_displayOptions([])
-      </select>
+#set ($clientId = "$!parameters.client")
+#if ($clientId == '')
+  #set ($clientId = $macroId)
+#end
+#set ($clientCfg = $services.projectmanagementlivedata.getLivedataConfiguration($macroId))
+#if ("$!clientCfg" != '')
+  #set ($propertiesJson = $clientCfg.meta.propertyDescriptors)
+  #set ($filterableProperties = [])
+  #foreach ($prop in $propertiesJson)
+    #if ($prop.filter && $prop.filter.id)
+      #set ($discard = $filterableProperties.add($prop))
+    #end
+  #end
+  #if ($$filterableProperties.isEmpty())
+    <p>The entries of this macro are not filterable at the moment.</p>
+  #else
+    <div class="projManagementConstraintBuilder" data-cfg="$escapetool.xml($jsontool.serialize($filterableProperties))">
+      <div>
+        <button id="addConstraint" class="btn btn-default">
+          $!escapetool.xml($services.localization.render('projectmanagement.macro.filter.addConstraint'))
+        </button>
+      </div>
+      <div class="projManagConstraints">
+      </div>
+      <div id="projManagConstraintTemplate" class="projManagConstraint">
+        <div class="projManagContainer projManagConstraintNameContainer">
+          <select class="projManagConstraintName">
+            #foreach ($prop in $filterableProperties)
+              <option value="$prop.id">$prop.id</option>
+            #end
+          </select>
+        </div>
+        <div class="projManagContainer projManagConstraintOperatorContainer">
+          <select class="projManagConstraintOperator">
+          </select>
+        </div>
+        <div class="projManagContainer projManagConstraintValueContainer">
+          <input class="projManagConstraintValue" type="text"
+            placeholder="$!escapetool.xml($services.localization.render('projectmanagement.macro.filter.placeholder'))" />
+        </div>
+      </div>
     </div>
-    <div>
-      <span>
-        $!escapetool.xml($services.localization.render('projectmanagement.macro.filter.constraint.equals'))
-      </span>
-    </div>
-    <div>
-      <input class="projManagConstraintValue" type="text"
-        placeholder="$!escapetool.xml($services.localization.render('projectmanagement.macro.filter.placeholder'))" />
-    </div>
-  </div>
-</div>
+  #end
+#else
+  <p>The entries of this macro are not filterable at the moment.</p>
+#end
 #end

--- a/project-management-openproject/project-management-openproject-macro/src/main/java/com/xwiki/projectmanagement/openproject/internal/macro/OpenProjectMacro.java
+++ b/project-management-openproject/project-management-openproject-macro/src/main/java/com/xwiki/projectmanagement/openproject/internal/macro/OpenProjectMacro.java
@@ -49,7 +49,7 @@ public class OpenProjectMacro extends AbstractProjectManagementMacro<OpenProject
     @Override
     public void processParameters(OpenProjectMacroParameters parameters)
     {
-        addToSourceParams(parameters, "client", "test");
+        addToSourceParams(parameters, "client", "openproject");
 
         String instance = parameters.getInstance();
         if (instance == null || instance.isEmpty()) {

--- a/project-management-openproject/project-management-openproject-macro/src/main/resources/openprojectProjectManagementLiveDataConfiguration.json
+++ b/project-management-openproject/project-management-openproject-macro/src/main/resources/openprojectProjectManagementLiveDataConfiguration.json
@@ -4,5 +4,495 @@
       "id": "projectmanagement",
       "translationPrefix": "openproject.livedata.property."
     }
+  },
+  "meta": {
+    "propertyDescriptors": [
+      {
+        "id": "identifier.value",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            },
+            {
+              "id": "!",
+              "name": "Not equals"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "type",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            },
+            {
+              "id": "!",
+              "name": "Not equals"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "summary.value",
+        "filterable": true,
+        "filter": {
+          "id": "text",
+          "operators": [
+            {
+              "id": "~",
+              "name": "Contains"
+            },
+            {
+              "id": "!~",
+              "name": "Does not contain"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "description",
+        "filterable": true,
+        "filter": {
+          "id": "text",
+          "operators": [
+            {
+              "id": "~",
+              "name": "Contains"
+            },
+            {
+              "id": "!~",
+              "name": "Does not contain"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "startDate",
+        "filterable": true,
+        "filter": {
+          "id": "date",
+          "operators": [
+            {
+              "id": "<t+",
+              "name": "in less than"
+            },
+            {
+              "id": ">t+",
+              "name": "in more than"
+            },
+            {
+              "id": "<t->",
+              "name": "less than days ago"
+            },
+            {
+              "id": ">t-",
+              "name": "more than days ago"
+            },
+            {
+              "id": "t-",
+              "name": "Days ago"
+            },
+            {
+              "id": "t+",
+              "name": "Days later"
+            },
+            {
+              "id": "t",
+              "name": "Today"
+            },
+            {
+              "id": "w",
+              "name": "This week"
+            },
+            {
+              "id": "=d",
+              "name": "On"
+            },
+            {
+              "id": "<>d",
+              "name": "Between"
+            },
+            {
+              "id": "!*",
+              "name": "Empty"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "dueDate",
+        "filterable": true,
+        "filter": {
+          "id": "date",
+          "operators": [
+            {
+              "id": "<t+",
+              "name": "in less than"
+            },
+            {
+              "id": ">t+",
+              "name": "in more than"
+            },
+            {
+              "id": "<t-",
+              "name": "less than days ago"
+            },
+            {
+              "id": ">t-",
+              "name": "more than days ago"
+            },
+            {
+              "id": "t-",
+              "name": "Days ago"
+            },
+            {
+              "id": "t+",
+              "name": "Days later"
+            },
+            {
+              "id": "t",
+              "name": "Today"
+            },
+            {
+              "id": "w",
+              "name": "This week"
+            },
+            {
+              "id": "=d",
+              "name": "On"
+            },
+            {
+              "id": "<>d",
+              "name": "Between"
+            },
+            {
+              "id": "!*",
+              "name": "Empty"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "progress",
+        "filterable": true,
+        "filter": {
+          "id": "number",
+          "operators": [
+            {
+              "id": "=",
+              "name": "is"
+            },
+            {
+              "id": "!",
+              "name": "is not"
+            },
+            {
+              "id": ">=",
+              "name": ">="
+            },
+            {
+              "id": "<=",
+              "name": "<="
+            },
+            {
+              "id": "*",
+              "name": "not empty"
+            },
+            {
+              "id": "!*",
+              "name": "empty"
+            }
+          ]
+        }
+      },
+      {
+        "id": "creationDate",
+        "filterable": true,
+        "filter": {
+          "id": "date",
+          "operators": [
+            {
+              "id": "<t-",
+              "name": "less than days ago"
+            },
+            {
+              "id": ">t-",
+              "name": "more than days ago"
+            },
+            {
+              "id": "t-",
+              "name": "Days ago"
+            },
+            {
+              "id": "t",
+              "name": "Today"
+            },
+            {
+              "id": "w",
+              "name": "This week"
+            },
+            {
+              "id": "=d",
+              "name": "On"
+            },
+            {
+              "id": "<>d",
+              "name": "Between"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "updateDate",
+        "filterable": true,
+        "filter": {
+          "id": "date",
+          "operators": [
+            {
+              "id": "<t-",
+              "name": "less than days ago"
+            },
+            {
+              "id": ">t-",
+              "name": "more than days ago"
+            },
+            {
+              "id": "t-",
+              "name": "Days ago"
+            },
+            {
+              "id": "t",
+              "name": "Today"
+            },
+            {
+              "id": "w",
+              "name": "This week"
+            },
+            {
+              "id": "=d",
+              "name": "On"
+            },
+            {
+              "id": "<>d",
+              "name": "Between"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "creator.value",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            },
+            {
+              "id": "!",
+              "name": "Not equals"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "assignees",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            },
+            {
+              "id": "!",
+              "name": "Not equals"
+            },
+            {
+              "id": "*",
+              "name": "Not empty"
+            },
+            {
+              "id": "!*",
+              "name": "Empty"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "priority",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            },
+            {
+              "id": "!",
+              "name": "Not equals"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "project.value",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      },
+      {
+        "id": "status",
+        "filterable": true,
+        "filter": {
+          "id": "list",
+          "operators": [
+            {
+              "id": "=",
+              "name": "Equals"
+            },
+            {
+              "id": "!",
+              "name": "Not equals"
+            },
+            {
+              "id": "o",
+              "name": "open"
+            },
+            {
+              "id": "c",
+              "name": "closed"
+            },
+            {
+              "id": "*",
+              "name": "not empty"
+            }
+          ],
+          "searchURL": "/someRestURLThatIsNotImplementedYet"
+        }
+      }
+    ],
+    "filters": [
+      {
+        "id": "text",
+        "operators": [
+          {
+            "id": "~",
+            "name": "Contains words"
+          },
+          {
+            "id": "!~",
+            "name": "Does not contain words"
+          },
+          {
+            "id": "**",
+            "name": "Search string"
+          },
+          {
+            "id": "*",
+            "name": "Not empty"
+          },
+          {
+            "id": "!*",
+            "name": "Is empty"
+          }
+        ],
+        "defaultOperator": "~"
+      },
+      {
+        "id": "number",
+        "operators": [
+          {
+            "id": ">=",
+            "name": "Greater of equal"
+          },
+          {
+            "id": "<=",
+            "name": "Lower or equal"
+          },
+          {
+            "id": "=",
+            "name": "Equals"
+          },
+          {
+            "id": "!",
+            "name": "Not equal"
+          }
+        ],
+        "defaultOperator": "="
+      },
+      {
+        "id": "boolean",
+        "operators": [
+          {
+            "id": "=",
+            "name": "Equals"
+          },
+          {
+            "id": "!",
+            "name": "Not equal"
+          }
+        ],
+        "trueValue": "true",
+        "falseValue": "false",
+        "defaultOperator": "="
+      },
+      {
+        "id": "date",
+        "operators": [
+          {
+            "id": "=",
+            "name": "Equals"
+          },
+          {
+            "id": "!",
+            "name": "Not equal"
+          }
+        ],
+        "dateFormat": "yyyy/MM/dd HH:mm",
+        "defaultOperator": "between"
+      },
+      {
+        "id": "list",
+        "operators": [
+          "equals",
+          "startsWith",
+          "contains",
+          "empty"
+        ],
+        "defaultOperator": "contains"
+      }
+    ]
   }
 }


### PR DESCRIPTION
* Changed the default livedata configuration to have all the properties unfilterable and uneditable by default.
* defined all the filters of the openproject properties
* Duplicated the test client into "openproject" client as the hint of the client implementation needs to fall in line with other configs and implementation
* improved the filter builder to take into consideration the livedata configuration that should contain the defined filters per property
* the abstractopenproj macro now transforms the filter parameter into a livedata config inside the content of the macro