### PR TITLE
#132: Provide a XIP

### DIFF
--- a/project-management-openproject/pom.xml
+++ b/project-management-openproject/pom.xml
@@ -36,6 +36,7 @@
     <module>project-management-openproject-macro</module>
     <module>project-management-openproject-ui</module>
     <module>project-management-openproject-api</module>
+    <module>project-management-openproject-xip</module>
   </modules>
 
   <properties>

--- a/project-management-openproject/project-management-openproject-xip/pom.xml
+++ b/project-management-openproject/project-management-openproject-xip/pom.xml
@@ -1,0 +1,70 @@
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.xwiki.projectmanagement</groupId>
+    <artifactId>project-management-openproject</artifactId>
+    <version>1.1.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>project-management-openproject-xip</artifactId>
+  <name>Project Management - Open Project - XIP</name>
+  <packaging>xip</packaging>
+  <description>XIP for offline installation of Project Management</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.xwiki.projectmanagement</groupId>
+      <artifactId>project-management-openproject-ui</artifactId>
+      <type>xar</type>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.xwiki.commons</groupId>
+          <artifactId>xwiki-commons-tool-extension-plugin</artifactId>
+          <version>${commons.version}</version>
+          <configuration>
+            <coreExtensions>
+              <!-- We exclude what is already in the WAR -->
+              <coreExtension>
+                <groupId>org.xwiki.platform</groupId>
+                <artifactId>xwiki-platform-distribution-war-dependencies</artifactId>
+                <version>${platform.version}</version>
+                <type>pom</type>
+              </coreExtension>
+            </coreExtensions>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <extensions>
+      <!-- Needed to add support for the "xip" packaging -->
+      <extension>
+        <groupId>org.xwiki.commons</groupId>
+        <artifactId>xwiki-commons-tool-extension-plugin</artifactId>
+        <version>${commons.version}</version>
+      </extension>
+    </extensions>
+  </build>
+</project>


### PR DESCRIPTION
Provide a XIP package for this project.

Note I put the XIP in submodule of OpenProject because from the design of the repository, it look like that something else than OpenProject could be added in this repos in side of OpenProject so I think the XIP should be dedicated for OpenProject.