### PR TITLE
Add the open project workpackage mentions support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <version>1.2.0-rc-4-SNAPSHOT</version>
   <name>Project Management - Parent POM</name>
   <properties>
-    <xwikipro.commons.version>1.3.1</xwikipro.commons.version>
+    <xwikipro.commons.version>1.4.70-SNAPSHOT</xwikipro.commons.version>
     <licensing.version>1.32.3</licensing.version>
     <urlshortener.version>1.3.3</urlshortener.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <version>1.2.0-rc-4-SNAPSHOT</version>
   <name>Project Management - Parent POM</name>
   <properties>
-    <xwikipro.commons.version>1.4.70-SNAPSHOT</xwikipro.commons.version>
+    <xwikipro.commons.version>1.4.0</xwikipro.commons.version>
     <licensing.version>1.32.3</licensing.version>
     <urlshortener.version>1.3.3</urlshortener.version>
   </properties>

--- a/project-management-openproject/project-management-openproject-api/pom.xml
+++ b/project-management-openproject/project-management-openproject-api/pom.xml
@@ -42,6 +42,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.xwiki.commons</groupId>
+      <artifactId>xwiki-pro-commons-api</artifactId>
+      <version>${xwikipro.commons.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.xwiki.projectmanagement</groupId>
       <artifactId>project-management-relations-api</artifactId>
       <version>${project.version}</version>

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/DefaultOpenProjectMentionsResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/DefaultOpenProjectMentionsResource.java
@@ -1,0 +1,173 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.openproject.internal.mentions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.rest.XWikiRestException;
+import org.xwiki.rest.internal.DomainObjectFactory;
+import org.xwiki.rest.internal.RangeIterable;
+import org.xwiki.rest.internal.Utils;
+import org.xwiki.rest.model.jaxb.Objects;
+import org.xwiki.rest.model.jaxb.SearchResults;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.api.Document;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xwiki.projectmanagement.openproject.internal.rest.BaseOpenProjectWikiSearchResource;
+import com.xwiki.projectmanagement.openproject.rest.mentions.OpenProjectMentionResource;
+import com.xwiki.urlshortener.URLShortenerException;
+import com.xwiki.urlshortener.URLShortenerManager;
+
+/**
+ * Default implementation of the {@link OpenProjectMentionResource}.
+ *
+ * @version $Id$
+ * @since 1.2.0
+ */
+@Component
+@Named("com.xwiki.projectmanagement.openproject.internal.mentions.DefaultOpenProjectMentionsResource")
+public class DefaultOpenProjectMentionsResource extends BaseOpenProjectWikiSearchResource
+    implements OpenProjectMentionResource
+{
+    @Inject
+    private URLShortenerManager urlShortenerManager;
+
+    @Inject
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @Override
+    public SearchResults getPagesMentioningWorkPackage(String workPackageId, String filterInstance, Integer number,
+        Integer start, String orderField, String order, Boolean withPrettyNames) throws XWikiRestException
+    {
+        String id = workPackageId;
+        if (!StringUtils.isEmpty(workPackageId)) {
+            try {
+                Integer.parseInt(workPackageId);
+            } catch (NumberFormatException e) {
+                throw new WebApplicationException(
+                    Response.status(Response.Status.BAD_REQUEST).entity("Work package id should be an integer.")
+                        .build());
+            }
+        } else {
+            id = "*";
+        }
+
+        StringBuilder statement = new StringBuilder();
+        statement.append(String.format("property.%s.%s:%s", OpenProjectMentionClassInitializer.CLASS_NAME,
+            OpenProjectMentionClassInitializer.PROP_WORK_PACKAGE_ID, id));
+
+        maybeAddInstanceFilter(statement, filterInstance);
+
+        return searchInternal(statement.toString(), number, start, orderField, order,
+            withPrettyNames);
+    }
+
+    @Override
+    public Objects getMentionsWithId(String pageId, String filterInstance, Integer number, Integer start,
+        Boolean withPrettyNames) throws XWikiRestException
+    {
+        try {
+
+            if (pageId == null || pageId.isEmpty()) {
+                throw new WebApplicationException(
+                    Response.status(Response.Status.BAD_REQUEST).entity("Missing page id.").build());
+            }
+            DocumentReference documentReference = urlShortenerManager.getDocumentReference(null, pageId);
+
+            if (documentReference == null) {
+                throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build());
+            }
+
+            return getMentions(documentReference, filterInstance, start, number, withPrettyNames);
+        } catch (URLShortenerException e) {
+            throw new WebApplicationException(
+                Response.serverError().entity(ExceptionUtils.getRootCauseMessage(e)).build());
+        }
+    }
+
+    @Override
+    public Objects getMentionsWithRef(String reference, String filterInstance, Integer number, Integer start,
+        Boolean withPrettyNames) throws XWikiRestException
+    {
+
+        return getMentions(documentReferenceResolver.resolve(reference), filterInstance, start, number,
+            withPrettyNames);
+    }
+
+    private Objects getMentions(DocumentReference documentReference, String filterInstance, Integer start,
+        Integer number,
+        Boolean withPrettyNames) throws XWikiRestException
+    {
+        try {
+
+            DocumentInfo documentInfo = getDocumentInfo(documentReference.getWikiReference().getName(),
+                documentReference.getSpaceReferences().stream().map(SpaceReference::getName)
+                    .collect(Collectors.toList()), documentReference.getName(), null, null, true, false);
+
+            Document doc = documentInfo.getDocument();
+
+            Objects objects = objectFactory.createObjects();
+
+            List<BaseObject> objectList =
+                getBaseObjects(doc.getDocumentReference()).stream().filter(java.util.Objects::nonNull).collect(
+                    Collectors.toList());
+
+            RangeIterable<BaseObject> ri = new RangeIterable<BaseObject>(objectList, start, number);
+
+            for (BaseObject object : ri) {
+                /* By deleting objects, some of them might become null, so we must check for this */
+                if (object != null) {
+                    objects.getObjectSummaries().add(
+                        DomainObjectFactory.createObjectSummary(objectFactory, uriInfo.getBaseUri(),
+                            Utils.getXWikiContext(componentManager), doc, object, false,
+                            Utils.getXWikiApi(componentManager), withPrettyNames));
+                }
+            }
+
+            return objects;
+        } catch (XWikiException e) {
+            throw new WebApplicationException(
+                Response.serverError().entity(ExceptionUtils.getRootCauseMessage(e)).build());
+        }
+    }
+
+    protected List<BaseObject> getBaseObjects(DocumentReference documentReference) throws XWikiException
+    {
+        XWikiContext xWikiContext = this.xcontextProvider.get();
+        XWikiDocument xwikiDocument = xWikiContext.getWiki().getDocument(documentReference, xWikiContext);
+
+        return xwikiDocument.getXObjects(OpenProjectMentionClassInitializer.REFERENCE);
+    }
+}

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/DocumentUpdatingListener.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/DocumentUpdatingListener.java
@@ -1,0 +1,61 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.openproject.internal.mentions;
+
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.xwiki.bridge.event.DocumentUpdatingEvent;
+import org.xwiki.index.TaskManager;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Hello there.
+ *
+ * @version $Id$
+ * @since 1.2.0
+ */
+public class DocumentUpdatingListener extends AbstractEventListener
+{
+    @Inject
+    private TaskManager taskManager;
+
+    /**
+     * Default constructor.
+     */
+    public DocumentUpdatingListener()
+    {
+        super("name", Collections.singletonList(new DocumentUpdatingEvent()));
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        XWikiDocument doc = (XWikiDocument) source;
+
+//        this.taskManager.addTask(doc.getDocumentReference().getWikiReference().getName(), doc.
+//        getId(), doc.getVersion(),
+//            MENTION_TASK_ID);
+    }
+}

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionClassInitializer.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionClassInitializer.java
@@ -1,0 +1,57 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.openproject.internal.mentions;
+
+import java.util.Arrays;
+
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
+import com.xpn.xwiki.objects.classes.BaseClass;
+
+/**
+ * Hello there.
+ *
+ * @version $Id$
+ * @since 1.2.0
+ */
+public class OpenProjectMentionClassInitializer extends AbstractMandatoryClassInitializer
+{
+    /**
+     * Reference of the xwiki class.
+     */
+    public static final LocalDocumentReference REFERENCE = new LocalDocumentReference(Arrays.asList("OpenProject",
+        "Code"), "MentionClass");
+
+    /**
+     * Default constructor.
+     */
+    public OpenProjectMentionClassInitializer()
+    {
+        super(REFERENCE, "Open Project Work Package Mention");
+    }
+
+    @Override
+    protected void createClass(BaseClass xclass)
+    {
+        xclass.addTextField("workPackageId", "Identifier of the WorkPackage", 20);
+        xclass.addTextField("instance", "The name of the configured OpenProject instance", 20);
+    }
+}

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionClassInitializer.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionClassInitializer.java
@@ -21,6 +21,10 @@ package com.xwiki.projectmanagement.openproject.internal.mentions;
 
 import java.util.Arrays;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.LocalDocumentReference;
 
 import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
@@ -32,8 +36,26 @@ import com.xpn.xwiki.objects.classes.BaseClass;
  * @version $Id$
  * @since 1.2.0
  */
+@Component
+@Named(OpenProjectMentionClassInitializer.CLASS_NAME)
+@Singleton
 public class OpenProjectMentionClassInitializer extends AbstractMandatoryClassInitializer
 {
+    /**
+     * asda.
+     */
+    public static final String PROP_WORK_PACKAGE_ID = "workPackageId";
+
+    /**
+     * asdads.
+     */
+    public static final String PROP_INSTANCE = "instance";
+
+    /**
+     * Adasdas.
+     */
+    public static final String CLASS_NAME = "OpenProject.Code.MentionClass";
+
     /**
      * Reference of the xwiki class.
      */
@@ -51,7 +73,7 @@ public class OpenProjectMentionClassInitializer extends AbstractMandatoryClassIn
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField("workPackageId", "Identifier of the WorkPackage", 20);
-        xclass.addTextField("instance", "The name of the configured OpenProject instance", 20);
+        xclass.addTextField(PROP_WORK_PACKAGE_ID, "Identifier of the WorkPackage", 20);
+        xclass.addTextField(PROP_INSTANCE, "The name of the configured OpenProject instance", 20);
     }
 }

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionClassInitializer.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionClassInitializer.java
@@ -31,7 +31,7 @@ import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Hello there.
+ * Initializes the mention xobject that will hold the id of work packages.
  *
  * @version $Id$
  * @since 1.2.0
@@ -42,17 +42,17 @@ import com.xpn.xwiki.objects.classes.BaseClass;
 public class OpenProjectMentionClassInitializer extends AbstractMandatoryClassInitializer
 {
     /**
-     * asda.
+     * The name of the property that will hold the work package id.
      */
     public static final String PROP_WORK_PACKAGE_ID = "workPackageId";
 
     /**
-     * asdads.
+     * The name of the property that will hold the OpenProject instance id.
      */
     public static final String PROP_INSTANCE = "instance";
 
     /**
-     * Adasdas.
+     * The full class name of the mention.
      */
     public static final String CLASS_NAME = "OpenProject.Code.MentionClass";
 

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionSchedulingListener.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionSchedulingListener.java
@@ -36,7 +36,7 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 /**
- * Hello there.
+ * Queues the task responsible with the creation of mention objects.
  *
  * @version $Id$
  * @since 1.2.0

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionSchedulingListener.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionSchedulingListener.java
@@ -19,15 +19,20 @@
  */
 package com.xwiki.projectmanagement.openproject.internal.mentions;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
-import org.xwiki.bridge.event.DocumentUpdatingEvent;
+import org.xwiki.bridge.event.DocumentCreatedEvent;
+import org.xwiki.bridge.event.DocumentUpdatedEvent;
+import org.xwiki.component.annotation.Component;
 import org.xwiki.index.TaskManager;
 import org.xwiki.observation.AbstractEventListener;
 import org.xwiki.observation.event.Event;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 /**
@@ -36,7 +41,10 @@ import com.xpn.xwiki.doc.XWikiDocument;
  * @version $Id$
  * @since 1.2.0
  */
-public class DocumentUpdatingListener extends AbstractEventListener
+@Component
+@Singleton
+@Named("com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionSchedulingListener")
+public class OpenProjectMentionSchedulingListener extends AbstractEventListener
 {
     @Inject
     private TaskManager taskManager;
@@ -44,18 +52,22 @@ public class DocumentUpdatingListener extends AbstractEventListener
     /**
      * Default constructor.
      */
-    public DocumentUpdatingListener()
+    public OpenProjectMentionSchedulingListener()
     {
-        super("name", Collections.singletonList(new DocumentUpdatingEvent()));
+        super(OpenProjectMentionSchedulingListener.class.getName(),
+            Arrays.asList(new DocumentUpdatedEvent(), new DocumentCreatedEvent()));
     }
 
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
+        XWikiContext context = (XWikiContext) data;
         XWikiDocument doc = (XWikiDocument) source;
+        if (context.get(OpenProjectMentionTask.TASK_EXECUTING_KEY) != null) {
+            return;
+        }
 
-//        this.taskManager.addTask(doc.getDocumentReference().getWikiReference().getName(), doc.
-//        getId(), doc.getVersion(),
-//            MENTION_TASK_ID);
+        this.taskManager.addTask(doc.getDocumentReference().getWikiReference().getName(), doc.
+            getId(), OpenProjectMentionTask.TASK_ID);
     }
 }

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTask.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTask.java
@@ -1,0 +1,135 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.openproject.internal.mentions;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.index.IndexException;
+import org.xwiki.index.TaskConsumer;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.MacroExecutionException;
+
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.DocumentRevisionProvider;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xwiki.commons.document.MacroBlockFinder;
+
+import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionClassInitializer.REFERENCE;
+
+/**
+ * Hello there.
+ *
+ * @version $Id$
+ * @since 1.2.0
+ */
+public class OpenProjectMentionTask implements TaskConsumer
+{
+    private static final Pattern WORK_PACKAGE_URL_ID_PATTERN = Pattern.compile(".*/work_packages/(\\d+).*");
+
+    private static final Pattern WORK_PACKAGE_ID_PATTERN = Pattern.compile(".*/work_pa2ckages/(\\d+).*");
+
+    @Inject
+    private DocumentRevisionProvider documentRevisionProvider;
+
+    @Inject
+    private MacroBlockFinder macroBlockFinder;
+
+    @Override
+    public void consume(DocumentReference documentReference, String version) throws IndexException
+    {
+        try {
+            XWikiDocument doc = this.documentRevisionProvider.getRevision(documentReference, version);
+            List<MacroBlock> opMacros = new ArrayList<>();
+            macroBlockFinder.find(doc.getXDOM(), doc.getSyntax(), macroBlock -> {
+                if (!"openproject".equals(macroBlock.getId())) {
+                    return MacroBlockFinder.Lookup.CONTINUE;
+                }
+                String opInstance = macroBlock.getParameter("instance");
+                if (StringUtils.isEmpty(opInstance)) {
+                    return MacroBlockFinder.Lookup.CONTINUE;
+                }
+
+                if (!StringUtils.isEmpty(macroBlock.getParameter("filter"))) {
+                    return MacroBlockFinder.Lookup.CONTINUE;
+                }
+
+                opMacros.add(macroBlock);
+
+                return MacroBlockFinder.Lookup.CONTINUE;
+            });
+
+            if (opMacros.isEmpty()) {
+                return;
+            }
+
+            int existingObjs = doc.getXObjectSize(REFERENCE);
+            doc.removeXObjects(REFERENCE);
+
+            Iterator<MacroBlock> it = opMacros.iterator();
+            int added = 0;
+            while (it.hasNext()) {
+                MacroBlock macroBlock = it.next();
+                String workPackageId = getWorkPackageId(macroBlock.getParameter("identifier"));
+                if (workPackageId == null) {
+                    continue;
+                }
+            }
+        } catch (XWikiException e) {
+            throw new RuntimeException(e);
+        } catch (MacroExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getWorkPackageId(String identifierParam)
+    {
+        if (StringUtils.isEmpty(identifierParam)) {
+            return null;
+        }
+        // The id parameter can be either an URL that might point to a single work package.
+        try {
+            new URL(identifierParam);
+            Matcher matcher = WORK_PACKAGE_URL_ID_PATTERN.matcher(identifierParam);
+            if (!matcher.find()) {
+                // MALFORMED URL? MAYBE LOG AN ERROR
+                return null;
+            }
+            return matcher.group(1);
+        } catch (MalformedURLException ignored) {
+        }
+        // Or it can be a single id or a list of ids. We are only interested if it displays a single id.
+        try {
+            Integer.parseInt(identifierParam);
+            return identifierParam;
+        } catch (NumberFormatException ignored) {
+        }
+        return null;
+    }
+}

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTask.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTask.java
@@ -22,25 +22,34 @@ package com.xwiki.projectmanagement.openproject.internal.mentions;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
 import org.xwiki.index.IndexException;
 import org.xwiki.index.TaskConsumer;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.user.UserReferenceSerializer;
 
-import com.xpn.xwiki.XWikiException;
-import com.xpn.xwiki.doc.DocumentRevisionProvider;
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
 import com.xwiki.commons.document.MacroBlockFinder;
 
+import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionClassInitializer.PROP_INSTANCE;
+import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionClassInitializer.PROP_WORK_PACKAGE_ID;
 import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionClassInitializer.REFERENCE;
 
 /**
@@ -49,63 +58,131 @@ import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProj
  * @version $Id$
  * @since 1.2.0
  */
+@Component
+@Singleton
+@Named(OpenProjectMentionTask.TASK_ID)
 public class OpenProjectMentionTask implements TaskConsumer
 {
+    /**
+     * ADASD.
+     */
+    public static final String TASK_ID = "openprojectmention";
+
+    /**
+     * ADsada.
+     */
+    public static final String TASK_EXECUTING_KEY = TASK_ID + "executing";
+
     private static final Pattern WORK_PACKAGE_URL_ID_PATTERN = Pattern.compile(".*/work_packages/(\\d+).*");
 
     private static final Pattern WORK_PACKAGE_ID_PATTERN = Pattern.compile(".*/work_pa2ckages/(\\d+).*");
 
-    @Inject
-    private DocumentRevisionProvider documentRevisionProvider;
+    private static final String IDENTIFIER = "identifier";
 
     @Inject
     private MacroBlockFinder macroBlockFinder;
 
+    @Inject
+    private Provider<XWikiContext> xWikiContextProvider;
+
+    @Inject
+    @Named("document")
+    private UserReferenceSerializer<DocumentReference> documentUserSerializer;
+
+    @Inject
+    private Logger logger;
+
     @Override
     public void consume(DocumentReference documentReference, String version) throws IndexException
     {
+        XWikiContext context = xWikiContextProvider.get();
+        context.put(TASK_EXECUTING_KEY, true);
+
         try {
-            XWikiDocument doc = this.documentRevisionProvider.getRevision(documentReference, version);
-            List<MacroBlock> opMacros = new ArrayList<>();
-            macroBlockFinder.find(doc.getXDOM(), doc.getSyntax(), macroBlock -> {
-                if (!"openproject".equals(macroBlock.getId())) {
-                    return MacroBlockFinder.Lookup.CONTINUE;
-                }
-                String opInstance = macroBlock.getParameter("instance");
-                if (StringUtils.isEmpty(opInstance)) {
-                    return MacroBlockFinder.Lookup.CONTINUE;
-                }
+            logger.debug("Creating OP mentions for [{}].", documentReference);
+            XWikiDocument doc = context.getWiki().getDocument(documentReference, context);
+            List<MacroBlock> opMacros = getMacroBlocks(doc);
 
-                if (!StringUtils.isEmpty(macroBlock.getParameter("filter"))) {
-                    return MacroBlockFinder.Lookup.CONTINUE;
-                }
-
-                opMacros.add(macroBlock);
-
-                return MacroBlockFinder.Lookup.CONTINUE;
-            });
-
-            if (opMacros.isEmpty()) {
+            List<BaseObject> existingObjs = doc.getXObjects(REFERENCE);
+            logger.debug("Found [{}] OP macros and [{}] existing mention objects.", opMacros.size(),
+                existingObjs.size());
+            if (shouldSkipProcessing(opMacros, existingObjs)) {
                 return;
             }
-
-            int existingObjs = doc.getXObjectSize(REFERENCE);
             doc.removeXObjects(REFERENCE);
 
-            Iterator<MacroBlock> it = opMacros.iterator();
-            int added = 0;
-            while (it.hasNext()) {
-                MacroBlock macroBlock = it.next();
-                String workPackageId = getWorkPackageId(macroBlock.getParameter("identifier"));
-                if (workPackageId == null) {
-                    continue;
+            for (MacroBlock opMacro : opMacros) {
+                String workPackageId = opMacro.getParameter(IDENTIFIER);
+                BaseObject object = doc.newXObject(REFERENCE, context);
+                object.setStringValue(PROP_WORK_PACKAGE_ID, workPackageId);
+                object.setStringValue(PROP_INSTANCE, opMacro.getParameter(PROP_INSTANCE));
+                logger.debug("Created mention for work package with id [{}] and instance [{}].", workPackageId,
+                    opMacro.getParameter(PROP_INSTANCE));
+            }
+
+//            DocumentReference currentContextUser = context.getUserReference();
+//            context.setUserReference(documentUserSerializer.serialize(doc.getAuthors().getEffectiveMetadataAuthor()));
+            // Don't create a history entry.
+            doc.setMetaDataDirty(false);
+            doc.setContentDirty(false);
+            context.getWiki().saveDocument(doc, context);
+//            context.setUserReference(currentContextUser);
+        } catch (Exception e) {
+            logger.warn("Failed to create the OpenProject mention objects for the document [{}]. Cause: [{}]",
+                documentReference, ExceptionUtils.getRootCauseMessage(e));
+        } finally {
+            context.remove(TASK_EXECUTING_KEY);
+        }
+    }
+
+    private boolean shouldSkipProcessing(List<MacroBlock> opMacros, List<BaseObject> existingObjs)
+    {
+        if (opMacros.isEmpty() && existingObjs.isEmpty()) {
+            return true;
+        }
+
+        if (opMacros.size() == existingObjs.size()) {
+            for (int i = 0; i < opMacros.size(); i++) {
+                MacroBlock macroBlock = opMacros.get(i);
+                BaseObject obj = existingObjs.get(i);
+                if (!macroBlock.getParameter(IDENTIFIER).equals(obj.getStringValue(PROP_WORK_PACKAGE_ID))
+                    || !macroBlock.getParameter(PROP_INSTANCE).equals(obj.getStringValue(PROP_INSTANCE)))
+                {
+                    return false;
                 }
             }
-        } catch (XWikiException e) {
-            throw new RuntimeException(e);
-        } catch (MacroExecutionException e) {
-            throw new RuntimeException(e);
+            return true;
         }
+        return false;
+    }
+
+    private @NonNull List<MacroBlock> getMacroBlocks(XWikiDocument doc) throws MacroExecutionException
+    {
+        List<MacroBlock> opMacros = new ArrayList<>();
+        macroBlockFinder.find(doc.getXDOM(), doc.getSyntax(), macroBlock -> {
+            if (!"openproject".equals(macroBlock.getId())) {
+                return MacroBlockFinder.Lookup.CONTINUE;
+            }
+            String opInstance = macroBlock.getParameter(PROP_INSTANCE);
+            if (StringUtils.isEmpty(opInstance)) {
+                return MacroBlockFinder.Lookup.CONTINUE;
+            }
+
+            if (!StringUtils.isEmpty(macroBlock.getParameter("filter"))) {
+                return MacroBlockFinder.Lookup.CONTINUE;
+            }
+
+            String identifier = getWorkPackageId(macroBlock.getParameter(IDENTIFIER));
+            if (identifier == null) {
+                return MacroBlockFinder.Lookup.CONTINUE;
+            }
+            macroBlock.setParameter(IDENTIFIER, identifier);
+
+            opMacros.add(macroBlock);
+
+            return MacroBlockFinder.Lookup.CONTINUE;
+        });
+        return opMacros;
     }
 
     private String getWorkPackageId(String identifierParam)

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTask.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTask.java
@@ -53,7 +53,7 @@ import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProj
 import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionClassInitializer.REFERENCE;
 
 /**
- * Hello there.
+ * Searches the content of a xwiki page and creates objects for each valid work package mention.
  *
  * @version $Id$
  * @since 1.2.0
@@ -64,12 +64,12 @@ import static com.xwiki.projectmanagement.openproject.internal.mentions.OpenProj
 public class OpenProjectMentionTask implements TaskConsumer
 {
     /**
-     * ADASD.
+     * The id of the task.
      */
     public static final String TASK_ID = "openprojectmention";
 
     /**
-     * ADsada.
+     * The flag that marks when a document is saved during the execution of this task.
      */
     public static final String TASK_EXECUTING_KEY = TASK_ID + "executing";
 
@@ -120,13 +120,10 @@ public class OpenProjectMentionTask implements TaskConsumer
                     opMacro.getParameter(PROP_INSTANCE));
             }
 
-//            DocumentReference currentContextUser = context.getUserReference();
-//            context.setUserReference(documentUserSerializer.serialize(doc.getAuthors().getEffectiveMetadataAuthor()));
             // Don't create a history entry.
             doc.setMetaDataDirty(false);
             doc.setContentDirty(false);
             context.getWiki().saveDocument(doc, context);
-//            context.setUserReference(currentContextUser);
         } catch (Exception e) {
             logger.warn("Failed to create the OpenProject mention objects for the document [{}]. Cause: [{}]",
                 documentReference, ExceptionUtils.getRootCauseMessage(e));

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/BaseOpenProjectWikiSearchResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/BaseOpenProjectWikiSearchResource.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.openproject.internal.rest;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.xwiki.rest.XWikiRestException;
+import org.xwiki.rest.internal.Utils;
+import org.xwiki.rest.internal.resources.BaseSearchResult;
+import org.xwiki.rest.internal.resources.search.SearchSource;
+import org.xwiki.rest.model.jaxb.SearchResults;
+
+import com.xwiki.projectmanagement.relations.store.ProjectManagementRelation;
+
+/**
+ * Base wiki search resource that can be extended to search documents matching specific criteria across all the wikis.
+ *
+ * @version $Id$
+ * @since 1.2.0
+ */
+public class BaseOpenProjectWikiSearchResource extends BaseSearchResult
+{
+    protected static final String MULTIWIKI_QUERY_TEMPLATE_INFO =
+        "q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)"
+            + "(&prettyNames={false|true})(&wikis={wikis})(&className={classname})";
+
+    @Inject
+    @Named("solr")
+    protected SearchSource solrSearch;
+
+    protected SearchResults searchInternal(String query, Integer number, Integer start,
+        String orderField, String order, Boolean withPrettyNames) throws XWikiRestException
+    {
+        int limit = number;
+
+        try {
+            SearchResults searchResults = objectFactory.createSearchResults();
+            searchResults.setTemplate(String.format("%s?%s", uriInfo.getBaseUri().toString(),
+                MULTIWIKI_QUERY_TEMPLATE_INFO));
+
+            searchResults.getSearchResults().addAll(
+                this.solrSearch.search(
+                    query,
+                    getXWikiContext().getWikiId(),
+                    (String) null,
+                    Utils.getXWiki(componentManager).getRightService().hasProgrammingRights(
+                        Utils.getXWikiContext(componentManager)), orderField, order, (Boolean) true, limit, start,
+                    withPrettyNames, ProjectManagementRelation.CLASS_FULLNAME, uriInfo));
+
+            return searchResults;
+        } catch (Exception e) {
+            throw new XWikiRestException(e);
+        }
+    }
+
+    protected void maybeAddInstanceFilter(StringBuilder query, String filterInstance)
+    {
+        if (filterInstance == null || filterInstance.isEmpty()) {
+            return;
+        }
+        // TODO: Maybe we should enforce the instance names to be alphanumeric only.
+        query.append(String.format(" and link.cliemtParams like '%%%s%%'", filterInstance));
+    }
+}

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/document/DefaultOpenProjectDocumentResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/document/DefaultOpenProjectDocumentResource.java
@@ -24,7 +24,6 @@ import java.net.URI;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -57,7 +56,6 @@ import com.xwiki.urlshortener.URLShortenerManager;
  * @since 1.2.0-rc-1
  */
 @Component
-@Singleton
 @Named("com.xwiki.projectmanagement.openproject.internal.rest.document.DefaultOpenProjectDocumentResource")
 public class DefaultOpenProjectDocumentResource extends ModifiablePageResource
     implements OpenProjectDocumentResource, Initializable

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/document/DefaultOpenProjectLinkSearchResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/document/DefaultOpenProjectLinkSearchResource.java
@@ -20,19 +20,15 @@ package com.xwiki.projectmanagement.openproject.internal.rest.document;
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
-import org.xwiki.rest.internal.Utils;
-import org.xwiki.rest.internal.resources.BaseSearchResult;
-import org.xwiki.rest.internal.resources.search.SearchSource;
 import org.xwiki.rest.model.jaxb.SearchResults;
 
-import com.xwiki.projectmanagement.openproject.config.OpenProjectConfiguration;
+import com.xwiki.projectmanagement.openproject.internal.rest.BaseOpenProjectWikiSearchResource;
 import com.xwiki.projectmanagement.openproject.rest.document.OpenProjectLinkSearchResource;
 import com.xwiki.projectmanagement.relations.store.ProjectManagementRelation;
 
@@ -45,20 +41,9 @@ import com.xwiki.projectmanagement.relations.store.ProjectManagementRelation;
  */
 @Component
 @Named("com.xwiki.projectmanagement.openproject.internal.rest.document.DefaultOpenProjectLinkSearchResource")
-public class DefaultOpenProjectLinkSearchResource extends BaseSearchResult implements
+public class DefaultOpenProjectLinkSearchResource extends BaseOpenProjectWikiSearchResource implements
     OpenProjectLinkSearchResource
 {
-    private static final String MULTIWIKI_QUERY_TEMPLATE_INFO =
-        "q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)"
-            + "(&prettyNames={false|true})(&wikis={wikis})(&className={classname})";
-
-    @Inject
-    @Named("solr")
-    private SearchSource solrSearch;
-
-    @Inject
-    private OpenProjectConfiguration configuration;
-
     @Override
     public SearchResults getProjects(String projectId, String filterInstance, Integer number,
         Integer start, String orderField, String order, Boolean withPrettyNames) throws XWikiRestException
@@ -101,39 +86,5 @@ public class DefaultOpenProjectLinkSearchResource extends BaseSearchResult imple
 
         return searchInternal(statement.toString(), number, start, orderField, order,
             withPrettyNames);
-    }
-
-    private SearchResults searchInternal(String query, Integer number, Integer start,
-        String orderField, String order, Boolean withPrettyNames) throws XWikiRestException
-    {
-        int limit = number;
-
-        try {
-            SearchResults searchResults = objectFactory.createSearchResults();
-            searchResults.setTemplate(String.format("%s?%s", uriInfo.getBaseUri().toString(),
-                MULTIWIKI_QUERY_TEMPLATE_INFO));
-
-            searchResults.getSearchResults().addAll(
-                this.solrSearch.search(
-                    query,
-                    getXWikiContext().getWikiId(),
-                    (String) null,
-                    Utils.getXWiki(componentManager).getRightService().hasProgrammingRights(
-                        Utils.getXWikiContext(componentManager)), orderField, order, (Boolean) true, limit, start,
-                    withPrettyNames, ProjectManagementRelation.CLASS_FULLNAME, uriInfo));
-
-            return searchResults;
-        } catch (Exception e) {
-            throw new XWikiRestException(e);
-        }
-    }
-
-    private void maybeAddInstanceFilter(StringBuilder query, String filterInstance)
-    {
-        if (filterInstance == null || filterInstance.isEmpty()) {
-            return;
-        }
-        // TODO: Maybe we should enforce the instance names to be alphanumeric only.
-        query.append(String.format(" and link.cliemtParams like '%%%s%%'", filterInstance));
     }
 }

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/document/DefaultOpenProjectSpaceResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/document/DefaultOpenProjectSpaceResource.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -68,7 +67,6 @@ import com.xwiki.urlshortener.URLShortenerManager;
  * @since 1.2.0-rc-1
  */
 @Component
-@Singleton
 @Named("com.xwiki.projectmanagement.openproject.internal.rest.document.DefaultOpenProjectSpaceResource")
 public class DefaultOpenProjectSpaceResource extends XWikiResource implements OpenProjectSpaceResource
 {

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/rest/document/OpenProjectLinkObjectsResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/rest/document/OpenProjectLinkObjectsResource.java
@@ -59,7 +59,7 @@ public interface OpenProjectLinkObjectsResource
     @PUT
     Response link(
         @PathParam("id") String id,
-        @QueryParam("instanceId") @DefaultValue("") String instanceId,
+        @QueryParam("filterInstance") @DefaultValue("") String instanceId,
         @QueryParam("minorRevision") Boolean minorRevision,
         WorkPackageLink link
     ) throws XWikiRestException;

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/rest/mentions/OpenProjectMentionResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/rest/mentions/OpenProjectMentionResource.java
@@ -1,5 +1,3 @@
-package com.xwiki.projectmanagement.openproject.rest.document;
-
 /*
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +17,7 @@ package com.xwiki.projectmanagement.openproject.rest.document;
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package com.xwiki.projectmanagement.openproject.rest.mentions;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -27,37 +26,35 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 
 import org.xwiki.rest.XWikiRestException;
+import org.xwiki.rest.model.jaxb.Objects;
 import org.xwiki.rest.model.jaxb.SearchResults;
 
-import com.xwiki.projectmanagement.relations.model.ProjectManagementRelation;
-
 /**
- * Resource for retrieving pages containing {@link ProjectManagementRelation} to an Open Project entity.
+ * Endpoint for handling xwiki mentions to OpenProject packages.
  *
  * @version $Id$
- * @since 1.2.0-rc-1
+ * @since 1.2.0
  */
-@Path("/openproject/links")
-public interface OpenProjectLinkSearchResource
+@Path("/openproject")
+public interface OpenProjectMentionResource
 {
     /**
-     * @param projectId the OpenProject project id that should match the xwiki pages.
-     * @param forInstance the id of the OpenProject instance that should be taken into consideration when returning
-     *     links.
+     * @param workPackageId the OpenProject work package id that should match the xwiki pages.
+     * @param filterInstance the id of the OpenProject instance that should be taken into consideration when
+     *     returning mentions.
      * @param number the maximum number of elements that should be returned.
      * @param start the offset of the results.
      * @param orderField the field on which the results should be ordered on.
      * @param order how the results should be ordered. asc or desc.
      * @param withPrettyNames denotes whether the results should contain the pretty names of the documents or not.
-     * @return a list of xwiki pages that have a {@link ProjectManagementRelation} to an OpenProject entity and that the
-     *     current user has view rights on.
+     * @return a list of xwiki pages that mention the specified work package in their content.
      * @throws XWikiRestException if there was any issue retrieving the xwiki pages.
      */
     @GET
-    @Path("/projects/{id}")
-    SearchResults getProjects(
-        @PathParam("id") String projectId,
-        @QueryParam("filterInstance") @DefaultValue("") String forInstance,
+    @Path("/mentions")
+    SearchResults getPagesMentioningWorkPackage(
+        @QueryParam("workPackage") @DefaultValue("") String workPackageId,
+        @QueryParam("filterInstance") @DefaultValue("") String filterInstance,
         @QueryParam("number") @DefaultValue("25") Integer number,
         @QueryParam("start") @DefaultValue("0") Integer start,
         @QueryParam("orderField") @DefaultValue("") String orderField,
@@ -66,27 +63,39 @@ public interface OpenProjectLinkSearchResource
     ) throws XWikiRestException;
 
     /**
-     * @param workPackageId the OpenProject work package id that should match the xwiki pages.
+     * @param pageId the unique identifier of the page.
      * @param filterInstance the id of the OpenProject instance that should be taken into consideration when
-     *     returning links.
+     *     returning mentions.
      * @param number the maximum number of elements that should be returned.
      * @param start the offset of the results.
-     * @param orderField the field on which the results should be ordered on.
-     * @param order how the results should be ordered. asc or desc.
      * @param withPrettyNames denotes whether the results should contain the pretty names of the documents or not.
-     * @return a list of xwiki pages that have a {@link ProjectManagementRelation} to an OpenProject entity and that the
-     *     current user has view rights on.
+     * @return a list of mention objects that the requested page contains.
      * @throws XWikiRestException if there was any issue retrieving the xwiki pages.
      */
     @GET
-    @Path("/workPackages/{id}")
-    SearchResults getWorkPackages(
-        @PathParam("id") String workPackageId,
+    @Path("/documents/{id}/mentions")
+    Objects getMentionsWithId(
+        @PathParam("id") String pageId,
         @QueryParam("filterInstance") @DefaultValue("") String filterInstance,
-        @QueryParam("number") @DefaultValue("-1") Integer number,
+        @QueryParam("number") @DefaultValue("25") Integer number,
         @QueryParam("start") @DefaultValue("0") Integer start,
-        @QueryParam("orderField") @DefaultValue("") String orderField,
-        @QueryParam("order") @DefaultValue("asc") String order,
-        @QueryParam("prettyNames") @DefaultValue("false") Boolean withPrettyNames
-    ) throws XWikiRestException;
+        @QueryParam("prettyNames") @DefaultValue("false") Boolean withPrettyNames) throws XWikiRestException;
+
+    /**
+     * @param docRef the reference of the page.
+     * @param filterInstance the id of the OpenProject instance that should be taken into consideration when
+     *     returning mentions.
+     * @param number the maximum number of elements that should be returned.
+     * @param start the offset of the results.
+     * @param withPrettyNames denotes whether the results should contain the pretty names of the documents or not.
+     * @return a list of mention objects that the requested page contains.
+     * @throws XWikiRestException if there was any issue retrieving the xwiki pages.
+     */
+    @GET
+    @Path("/pages/{docRef}/mentions")
+    Objects getMentionsWithRef(@PathParam("docRef") String docRef,
+        @QueryParam("filterInstance") @DefaultValue("") String filterInstance,
+        @QueryParam("number") @DefaultValue("25") Integer number,
+        @QueryParam("start") @DefaultValue("0") Integer start,
+        @QueryParam("prettyNames") @DefaultValue("false") Boolean withPrettyNames) throws XWikiRestException;
 }

--- a/project-management-openproject/project-management-openproject-api/src/main/resources/META-INF/components.txt
+++ b/project-management-openproject/project-management-openproject-api/src/main/resources/META-INF/components.txt
@@ -1,6 +1,10 @@
 com.xwiki.projectmanagement.openproject.internal.displayer.OpenProjectDisplayerManager
 com.xwiki.projectmanagement.openproject.internal.displayer.StylingSetupManager
 com.xwiki.projectmanagement.openproject.internal.OpenProjectClient
+com.xwiki.projectmanagement.openproject.internal.mentions.DefaultOpenProjectMentionsResource
+com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionClassInitializer
+com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionSchedulingListener
+com.xwiki.projectmanagement.openproject.internal.mentions.OpenProjectMentionTask
 com.xwiki.projectmanagement.openproject.internal.config.DefaultOpenProjectConfiguration
 com.xwiki.projectmanagement.openproject.internal.config.OpenProjectDocumentConfigurationSource
 com.xwiki.projectmanagement.openproject.script.OpenProjectScriptService

--- a/project-management-openproject/project-management-openproject-api/src/test/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTaskTest.java
+++ b/project-management-openproject/project-management-openproject-api/src/test/java/com/xwiki/projectmanagement/openproject/internal/mentions/OpenProjectMentionTaskTest.java
@@ -1,0 +1,54 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.openproject.internal.mentions;
+
+public class OpenProjectMentionTaskTest
+{
+    void noMacrosInContentAndNoObjects()
+    {
+        // Nothing should happen. The document shouldnt be saved.
+    }
+
+    void macrosWithIdsInContentAndNoObjects()
+    {
+        // N objects should be created.
+    }
+
+    void macrosWithoutIdsInContentAndNoObjects()
+    {
+        // N - M macros should be created. Where N is total and M is macros without ids.
+    }
+
+    void macrosInContentAndAllAssociatedObjects()
+    {
+        // No changes in the content. Nothing should happen.
+    }
+
+    void macrosRemovedFromContent()
+    {
+        // There are objects of macros that were deleted. The objects should be deleted as well.
+    }
+
+    void macroIdUpdated()
+    {
+        // There is the same number of objects as macros. One of the macro was updated. The associated object should
+        // be updated.
+    }
+}


### PR DESCRIPTION
Created a listener that schedules the processing of documents.

Parse the document and create/remove Mention objects that can be queried later.

Create and endpoint for retrieving xwiki pages that mention a given open project id.
