### PR TITLE
Creating a work package with a milestone as parent silently fails while the UI reports success

### DIFF
--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/workPackages/HandleWorkPackages.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/workPackages/HandleWorkPackages.java
@@ -277,11 +277,13 @@ public class HandleWorkPackages extends XWikiResource
      * The resource that exposes the available options for creating a work package and creates the work package if the
      * provided options are valid.
      *
-     * @param workPackage the work package that needs to be created.
+     * @param workPackage the work package that needs to be created. When it is marked as
+     *     {@link CreateWorkPackage#getFormOnly()}, only the options of the creation form are returned.
      * @param wiki the wiki that contains the configured client.
      * @param instance the OpenProject client where to search for work item suggestions.
-     * @return the form response containing the validation errors if the creation failed or the created work package if
-     *     the creation succeeded.
+     * @return the options of the creation form when only the form is requested, the created work package when the
+     *     creation succeeded, or the options together with the first validation message and a 422 status when the work
+     *     package was rejected by OpenProject.
      * @since 1.1
      */
     @POST
@@ -300,13 +302,20 @@ public class HandleWorkPackages extends XWikiResource
 
             validateResponseType(response);
 
+            JsonNode schemaNode = getSchemaNode(response);
+
+            if (Boolean.TRUE.equals(workPackage.getFormOnly())) {
+                return Response.ok(
+                    convertFormResponseToOptionsResponse(schemaNode, objectMapper.createObjectNode())).build();
+            }
+
             JsonNode validationErrors = response.path(EMBEDDED).path(VALIDATION_ERRORS);
 
             if (!validationErrors.isEmpty()) {
-                JsonNode schemaNode = getSchemaNode(response);
                 Map<String, Object> optionsResponse = convertFormResponseToOptionsResponse(schemaNode,
                     objectMapper.createObjectNode());
-                return Response.status(Response.Status.OK).entity(optionsResponse).build();
+                optionsResponse.put(VALIDATION_MESSAGE, extractFirstValidationMessage(validationErrors));
+                return Response.status(UNPROCESSABLE_ENTITY).entity(optionsResponse).build();
             }
 
             String commitLink = response.path(LINKS).path(COMMIT).path(HREF).asText();

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/model/CreateWorkPackage.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/model/CreateWorkPackage.java
@@ -57,6 +57,8 @@ public class CreateWorkPackage
 
     private Integer lockVersion;
 
+    private Boolean formOnly;
+
     /**
      * Default constructor.
      */
@@ -333,5 +335,30 @@ public class CreateWorkPackage
     public void setLockVersion(Integer lockVersion)
     {
         this.lockVersion = lockVersion;
+    }
+
+    /**
+     * Getter for the flag marking a request that only builds the creation form. Such a request carries an
+     * intentionally incomplete work package, so the validation errors it triggers describe the fields that are still
+     * to be filled in and not a failed creation.
+     *
+     * @return true if the request only asks for the options of the creation form, false or null if it asks for the
+     *     creation of the work package.
+     * @since 1.2.1
+     */
+    public Boolean getFormOnly()
+    {
+        return formOnly;
+    }
+
+    /**
+     * Setter for the form only flag.
+     *
+     * @param formOnly see {@link #getFormOnly()}.
+     * @since 1.2.1
+     */
+    public void setFormOnly(Boolean formOnly)
+    {
+        this.formOnly = formOnly;
     }
 }

--- a/project-management-openproject/project-management-openproject-api/src/main/resources/js/openproject/createWorkPackagesUtils.js
+++ b/project-management-openproject/project-management-openproject-api/src/main/resources/js/openproject/createWorkPackagesUtils.js
@@ -160,6 +160,16 @@ define('create-work-package-utils', ['jquery', 'xwiki-l10n!openproject.createwor
 	  });
 	}
 
+	// Asks only for the options of the creation form. The work package sent along is incomplete on purpose, so the
+	// creation must not be attempted and the validation errors it would raise must not be reported.
+	let createWorkPackagesOptionsRequest = async function createWorkPackagesOptionsRequest(connection, requestBody) {
+	  return await createWorkPackagesRequest(connection, {...requestBody, formOnly: true});
+	}
+
+	let getValidationMessage = function getValidationMessage(err) {
+	  return err && err.responseJSON ? err.responseJSON.validationMessage : null;
+	}
+
 	let buildPayload = function buildPayload($container) {
 	  const payload = {};
 	  $container.find('input[name], select[name], textarea[name]').not('.wp-selected').each(function () {
@@ -364,7 +374,9 @@ define('create-work-package-utils', ['jquery', 'xwiki-l10n!openproject.createwor
 	  initProjectPicker: initProjectPicker,
 	  initDynamicSelectizeFields: initDynamicSelectizeFields,
 	  destroySelectize: destroySelectize,
-	  createWorkPackagesRequest: createWorkPackagesRequest
+	  createWorkPackagesRequest: createWorkPackagesRequest,
+	  createWorkPackagesOptionsRequest: createWorkPackagesOptionsRequest,
+	  getValidationMessage: getValidationMessage
 	}
 
   return createWPUtils;

--- a/project-management-openproject/project-management-openproject-api/src/test/java/com/xwiki/projectmanagement/openproject/internal/rest/workPackages/HandleWorkPackagesTest.java
+++ b/project-management-openproject/project-management-openproject-api/src/test/java/com/xwiki/projectmanagement/openproject/internal/rest/workPackages/HandleWorkPackagesTest.java
@@ -137,6 +137,8 @@ public class HandleWorkPackagesTest
     {
         CreateWorkPackage createWorkPackage = generateCreateWorkPackage();
 
+        createWorkPackage.setFormOnly(true);
+
         JsonNode workPackagesNode = mapper.readTree(
             OpenProjectTestUtils.getCreateWorkPackageValidationFailsApiResponse()
         );

--- a/project-management-openproject/project-management-openproject-api/src/test/resources/openProjectCreateWorkPackageValidationFailsApiResponse.json
+++ b/project-management-openproject/project-management-openproject-api/src/test/resources/openProjectCreateWorkPackageValidationFailsApiResponse.json
@@ -182,7 +182,8 @@
     },
     "validationErrors": {
       "subject": {
-        "_type": "Error"
+        "_type": "Error",
+        "message": "Subject can't be blank."
       }
     }
   }

--- a/project-management-openproject/project-management-openproject-macro/src/main/resources/openproject/js/createWorkPackage.js
+++ b/project-management-openproject/project-management-openproject-macro/src/main/resources/openproject/js/createWorkPackage.js
@@ -80,7 +80,7 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
     const requestBody = { project: project };
 
     try {
-      const response = await createWpUtils.createWorkPackagesRequest(connection, requestBody);
+      const response = await createWpUtils.createWorkPackagesOptionsRequest(connection, requestBody);
       container.empty().addClass("hidden");
 
       Object.entries(response).forEach(([key, value]) => {
@@ -146,7 +146,7 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
     });
     createWpUtils.notify(l10n.get("notify.submit.success"), "done");
     } catch (err) {
-      createWpUtils.notify(l10n.get("notify.submit.error"), "error");
+      createWpUtils.notify(createWpUtils.getValidationMessage(err) || l10n.get("notify.submit.error"), "error");
     }
   }
 

--- a/project-management-openproject/project-management-openproject-ui/src/main/resources/OpenProject/Code/CreateWorkPackagesExtensionPoint.xml
+++ b/project-management-openproject/project-management-openproject-ui/src/main/resources/OpenProject/Code/CreateWorkPackagesExtensionPoint.xml
@@ -561,7 +561,7 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
       };
 
       try {
-        const response = await createWpUtils.createWorkPackagesRequest(connection, requestBody);
+        const response = await createWpUtils.createWorkPackagesOptionsRequest(connection, requestBody);
 
         container.empty().addClass("hidden");
 
@@ -607,7 +607,7 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
       };
 
       try {
-        const response = await createWpUtils.createWorkPackagesRequest(connection, requestBody);
+        const response = await createWpUtils.createWorkPackagesOptionsRequest(connection, requestBody);
         generateCards(response, rowsData.map(() =&gt; ""));
 
         if ($(".mapping-row").length &gt; 0) {
@@ -654,8 +654,29 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
         createWpUtils.notify(l10n.get("notify.single.success"), "done");
         window.openProjectEvents.dispatchEvent(new CustomEvent("op-creation-success", { detail: { createdWp: response, connection: connection, element: selectedElement } }));
       } catch (err) {
-        createWpUtils.notify(l10n.get("notify.single.error"), "error")
+        createWpUtils.notify(createWpUtils.getValidationMessage(err) || l10n.get("notify.single.error"), "error")
       }
+    }
+
+    function showCardError(card, message) {
+      card.find('.wp-error').remove();
+
+      const error = $("&lt;div&gt;", {
+        class: "wp-error text-danger small",
+        text: message
+      });
+
+      const titleRow = card.find('.panel-body &gt; .row').first();
+
+      if (titleRow.length) {
+        titleRow.after(error);
+      } else {
+        card.find('.panel-body').append(error);
+      }
+    }
+        
+    function markCardAsCreated(card) {
+      card.find('.wp-selected').prop('checked', false).prop('disabled', true);
     }
 
     async function submitMultipleWorkPackagesForm(element) {
@@ -695,36 +716,43 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
 
         const titleEl = card.find('.wp-subject-title');
         titleEl.removeClass('text-success text-danger');
+        card.find('.wp-error').remove();
 
         const p = createWpUtils.createWorkPackagesRequest(connection, payload)
           .then(resp =&gt; {
             titleEl.addClass('text-success');
             window.openProjectEvents.dispatchEvent(new CustomEvent("op-creation-success", { detail: { createdWp: resp, connection: connection, element: rowExtraData._element, batch: true } }));
-            return { success: true, resp };
+            return { success: true, resp, card };
           })
           .catch(err =&gt; {
             titleEl.addClass('text-danger');
-            return { success: false, err };
+            showCardError(card, createWpUtils.getValidationMessage(err) || l10n.get('notify.single.error'));
+            return { success: false, err, card };
           });
 
         tasks.push(p);
       });
 
-      if (tasks.length === 0) {
-        createWpUtils.notify(l10n.get('notify.multiple.noSelection'), 'warning');
+      const results = await Promise.all(tasks);
+      const allSuccess = results.every(r =&gt; r.success === true);
+
+      const firstError = results.map(r =&gt; createWpUtils.getValidationMessage(r.err)).find(Boolean);
+
+      if (allSuccess) {
+        createWpUtils.notify(l10n.get('notify.multiple.allSuccess'), 'done');
+        $("#create-multiple-work-packages-form-button").addClass("hidden");
         return;
       }
 
-      const results = await Promise.all(tasks);
-      const allSuccess = results.every(r =&gt; r.success === true);
-      if (allSuccess) {
-        createWpUtils.notify(l10n.get('notify.multiple.allSuccess'), 'done');
-      } else if (results.some(r =&gt; r.success)) {
-        createWpUtils.notify(l10n.get('notify.multiple.partialSuccess'), 'warning');
+      // The work packages that were created are taken out of the selection, so that pressing create again retries
+      // only the ones that failed.
+      results.filter(r =&gt; r.success).forEach(r =&gt; markCardAsCreated(r.card));
+
+      if (results.some(r =&gt; r.success)) {
+        createWpUtils.notify(firstError || l10n.get('notify.multiple.partialSuccess'), 'error');
       } else {
-        createWpUtils.notify(l10n.get('notify.multiple.error'), 'error');
+        createWpUtils.notify(firstError || l10n.get('notify.multiple.error'), 'error');
       }
-      $("#create-multiple-work-packages-form-button").addClass("hidden");
     }
 
     function renderSingleMode() {
@@ -827,12 +855,12 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
 
     $(document).on('change', '#select-all-work-packages', function () {
       const checked = $(this).is(':checked');
-      $('#work-packages-container .wp-selected').prop('checked', checked);
+      $('#work-packages-container .wp-selected:not(:disabled)').prop('checked', checked);
     });
 
     $(document).on('change', '.wp-selected', function () {
-      const total = $('#work-packages-container .wp-selected').length;
-      const checked = $('#work-packages-container .wp-selected:checked').length;
+      const total = $('#work-packages-container .wp-selected:not(:disabled)').length;
+      const checked = $('#work-packages-container .wp-selected:not(:disabled):checked').length;
 
       $('#select-all-work-packages').prop('checked', total === checked);
     });


### PR DESCRIPTION
Besides the reported bug, this PR also improves the error handling of the create work package flows: the reason given by OpenProject is now displayed instead of a generic message, and in the create from table flow each failed card shows its own reason. A partially failed batch is now reported as an error and keeps the create button, with the created work packages unselected and locked, so pressing create again retries only the ones that failed.