### PR TITLE
Create work packages macro stops working after the modal is closed and reopened

### DIFF
--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/workPackages/HandleWorkPackages.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/workPackages/HandleWorkPackages.java
@@ -292,6 +292,14 @@ public class HandleWorkPackages extends XWikiResource
         @PathParam("instance") String instance, CreateWorkPackage workPackage) throws ProjectManagementException
     {
         OpenProjectApiClient apiClient = openProjectConfiguration.getOpenProjectApiClient(instance);
+
+        if (apiClient == null) {
+            return Response
+                .status(Response.Status.CONFLICT)
+                .entity(NO_AUTHENTICATION_ERROR_MESSAGE)
+                .build();
+        }
+
         Map<String, Object> formRequest = createRequestForOpenProjectFormRequest(workPackage);
 
         JsonNode response;
@@ -382,6 +390,14 @@ public class HandleWorkPackages extends XWikiResource
         throws ProjectManagementException
     {
         OpenProjectApiClient apiClient = openProjectConfiguration.getOpenProjectApiClient(instance);
+
+        if (apiClient == null) {
+            return Response
+                .status(Response.Status.CONFLICT)
+                .entity(NO_AUTHENTICATION_ERROR_MESSAGE)
+                .build();
+        }
+
         Map<String, Object> formRequest = createRequestForOpenProjectFormRequest(workPackage);
 
         try {

--- a/project-management-openproject/project-management-openproject-macro/src/main/resources/openproject/js/createWorkPackage.js
+++ b/project-management-openproject/project-management-openproject-macro/src/main/resources/openproject/js/createWorkPackage.js
@@ -94,7 +94,9 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
 
       container.removeClass("hidden");
     } catch (err) {
-      createWpUtils.notify(l10n.get("notify.inputs.error"), "error");
+      if (err.status !== 409) {
+        createWpUtils.notify(l10n.get("notify.inputs.error"), "error");
+      }
     }
   }
 
@@ -198,8 +200,30 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
     );
   });
 
-  $(document).on("show.bs.modal", ".macro-editor-modal", function () {
-	  initializeConnectionIfOnlyOneAvailable();
+  $(document).on("shown.bs.modal", ".macro-editor-modal", function () {
+    let modal = $(this);
+    setTimeout(function () {
+      const content = modal.find('.macro-editor');
+      if (!content || content.length <= 0) {
+        return;
+      }
+      if (!content[0].classList.contains('loading')) {
+        initializeConnectionIfOnlyOneAvailable();
+        return;
+      }
+      const observer = new MutationObserver(() => {
+        if (!content[0].classList.contains('loading')) {
+          observer.disconnect();
+          initializeConnectionIfOnlyOneAvailable();
+        }
+      });
+
+      observer.observe(content[0], {
+        attributes: true,
+        attributeFilter: ['class'],
+        subtree: true
+      });
+    });
   });
 
 	initializeConnectionIfOnlyOneAvailable();

--- a/project-management-openproject/project-management-openproject-ui/src/main/resources/OpenProject/Code/CreateWorkPackagesExtensionPoint.xml
+++ b/project-management-openproject/project-management-openproject-ui/src/main/resources/OpenProject/Code/CreateWorkPackagesExtensionPoint.xml
@@ -588,6 +588,9 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
 
         container.removeClass("hidden");
       } catch (err) {
+        if (err.status === 409) {
+          return;
+        }
         createWpUtils.notify(l10n.get("notify.inputs.error"), "error");
       }
     }
@@ -617,6 +620,9 @@ require(["jquery", "create-work-package-utils", "xwiki-l10n!openproject.createwo
           initializeMapping(response);
         }
       } catch (err) {
+        if (err.status === 409) {
+          return;
+        }
         createWpUtils.notify(l10n.get("notify.values.error"), "error")
       }
     }


### PR DESCRIPTION
Besides the reported bug, this PR also fixes the error notification that was displayed when selecting a connection that was not authenticated.