### PR TITLE
Add the possibility to run custom logic in the async renderer #237

### DIFF
--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/displayers/AbstractWorkItemsDisplayer.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/displayers/AbstractWorkItemsDisplayer.java
@@ -89,7 +89,7 @@ public abstract class AbstractWorkItemsDisplayer extends AbstractWorkItemsMacro<
 
         List<LiveDataQuery.Filter> filters;
         try {
-            filters = getFilters(content);
+            filters = getFilters(parameters.getFilters());
         } catch (LiveDataException e) {
             throw new MacroExecutionException("Failed to parse the filters.");
         }

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/displayers/WorkItemLivedataDisplayer.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/displayers/WorkItemLivedataDisplayer.java
@@ -79,10 +79,15 @@ public class WorkItemLivedataDisplayer extends AbstractMacro<ProjectManagementMa
         try {
             Macro<ProjectManagementAsyncMacroParams> displayerMacro =
                 componentManager.getInstance(Macro.class, "liveData");
+            String newContent = content;
+            if (parameters.getFilters() != null && !parameters.getFilters().isEmpty()) {
+                newContent = parameters.getFilters();
+                parameters.setFilters("");
+            }
             if (WorkItemsDisplayer.liveDataCards.equals(parameters.getWorkItemsDisplayer())) {
                 parameters.setLayouts("cards,table");
             }
-            return displayerMacro.execute(parameters, content, context);
+            return displayerMacro.execute(parameters, newContent, context);
         } catch (ComponentLookupException e) {
             throw new MacroExecutionException("Could not find the [liveData] macro.", e);
         }

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/displayers/WorkItemLivedataDisplayer.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/displayers/WorkItemLivedataDisplayer.java
@@ -1,0 +1,90 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.projectmanagement.internal.displayers;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.macro.AbstractMacro;
+import org.xwiki.rendering.macro.Macro;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+
+import com.xwiki.projectmanagement.internal.WorkItemsDisplayer;
+import com.xwiki.projectmanagement.macro.ProjectManagementAsyncMacroParams;
+import com.xwiki.projectmanagement.macro.ProjectManagementMacroParameters;
+
+/**
+ * Wraps the LIVEDATA macro in order to use it with the
+ * {@link com.xwiki.projectmanagement.internal.macro.ProjectManagementAsyncExecutor}.
+ *
+ * @version $Id$
+ * @since 1.3.0
+ */
+@Singleton
+@Named(WorkItemLivedataDisplayer.ROLE_HINT)
+@Component
+public class WorkItemLivedataDisplayer extends AbstractMacro<ProjectManagementMacroParameters>
+{
+    /**
+     * The hint of this component.
+     */
+    public static final String ROLE_HINT = "proj-manag-liveData";
+
+    @Inject
+    private ComponentManager componentManager;
+
+    /**
+     * Default constructor.
+     */
+    public WorkItemLivedataDisplayer()
+    {
+        super("Work Items Livedata macro", "Wraps the livedata macro to provide project management logic.");
+    }
+
+    @Override
+    public boolean supportsInlineMode()
+    {
+        return false;
+    }
+
+    @Override
+    public List<Block> execute(ProjectManagementMacroParameters parameters, String content,
+        MacroTransformationContext context) throws MacroExecutionException
+    {
+        try {
+            Macro<ProjectManagementAsyncMacroParams> displayerMacro =
+                componentManager.getInstance(Macro.class, "liveData");
+            if (WorkItemsDisplayer.liveDataCards.equals(parameters.getWorkItemsDisplayer())) {
+                parameters.setLayouts("cards,table");
+            }
+            return displayerMacro.execute(parameters, content, context);
+        } catch (ComponentLookupException e) {
+            throw new MacroExecutionException("Could not find the [liveData] macro.", e);
+        }
+    }
+}

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementChartMacro.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementChartMacro.java
@@ -138,7 +138,7 @@ public abstract class AbstractProjectManagementChartMacro<T extends ProjectManag
                         throw new MacroExecutionException("Failed to retrieve the work packages.", e);
                     }
                 }
-            }, parameters, content, context);
+            }, parameters, content, context, null, true);
             // TODO: Remove when parent is greater than 18.6.0-rc-1. When displaying multiple charts on the same
             //  page, they get initialised on page load and on xwiki:dom:updated event. This event is sent, when
             //  rendering things async, since 18.6.0-rc-1. We need some way around it until then.

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
@@ -23,6 +23,7 @@ package com.xwiki.projectmanagement.internal.macro;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
@@ -38,13 +39,17 @@ import org.xwiki.rendering.macro.descriptor.ContentDescriptor;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 
 import com.xwiki.projectmanagement.internal.WorkItemsDisplayer;
+import com.xwiki.projectmanagement.internal.displayers.WorkItemLivedataDisplayer;
 import com.xwiki.projectmanagement.macro.ProjectManagementAsyncMacroParams;
 import com.xwiki.projectmanagement.macro.ProjectManagementMacroParameters;
 
 /**
- * Something.
+ * Provides the logic and extension points for implementing the base work item filtering macro. When implementing a
+ * project management client, this macro should also be implemented and minimally add the client ID to the source
+ * parameters.
  *
- * @param <T> something.
+ * @param <T> the type of your macro implementation parameters. This will allow you to add custom parameters for the
+ *     macro implementation.
  * @version $Id$
  */
 public abstract class AbstractProjectManagementMacro<T extends ProjectManagementMacroParameters>
@@ -57,10 +62,10 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
     private ProjectManagementAsyncExecutor asyncExecutor;
 
     /**
-     * @param name smth
-     * @param description smth
-     * @param descriptor smth
-     * @param clazz smth
+     * @param name the name of the macro.
+     * @param description the description of the macro.
+     * @param descriptor the content descriptor of the macro.
+     * @param clazz the class of the parameters.
      */
     public AbstractProjectManagementMacro(String name, String description, ContentDescriptor descriptor,
         Class<?> clazz)
@@ -98,9 +103,8 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
         }
         try {
             String displayerId = displayer.name();
-            if (WorkItemsDisplayer.liveDataCards.equals(displayer)) {
-                parameters.setLayouts("cards,table");
-                displayerId = WorkItemsDisplayer.liveData.name();
+            if (WorkItemsDisplayer.liveDataCards.equals(displayer) || WorkItemsDisplayer.liveData.equals(displayer)) {
+                displayerId = WorkItemLivedataDisplayer.ROLE_HINT;
             }
             Macro<ProjectManagementAsyncMacroParams> displayerMacro =
                 componentManager.getInstance(Macro.class, displayerId);
@@ -108,11 +112,8 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
                 throw new MacroExecutionException(
                     String.format("Macro displayer [%s] is standalone but is being used inline.", displayerId));
             }
-            if (!WorkItemsDisplayer.liveData.equals(displayer) && !WorkItemsDisplayer.liveDataCards.equals(displayer)) {
-                return asyncExecutor.execute(displayerMacro, parameters, newContent, context);
-            }
-
-            return displayerMacro.execute(parameters, newContent, context);
+            return asyncExecutor.execute(displayerMacro, parameters, newContent, context,
+                getAsyncParametersProcessor(), isAsync(parameters));
         } catch (ComponentLookupException e) {
             throw new MacroExecutionException(String.format("Could not find the displayer [%s].", displayer.name()), e);
         } catch (JobException | RenderingException e) {
@@ -126,6 +127,17 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
      * @param parameters the parameters that will be passed to the livedata macro call.
      */
     public abstract void processParameters(T parameters);
+
+    protected boolean isAsync(T parameters)
+    {
+        return !WorkItemsDisplayer.liveData.equals(parameters.getWorkItemsDisplayer())
+            && !WorkItemsDisplayer.liveDataCards.equals(parameters.getWorkItemsDisplayer());
+    }
+
+    protected Consumer<ProjectManagementAsyncRenderer> getAsyncParametersProcessor()
+    {
+        return null;
+    }
 
     protected void addToSourceParams(T parameters, String key, String value)
     {

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
@@ -67,8 +67,7 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
      * @param descriptor the content descriptor of the macro.
      * @param clazz the class of the parameters.
      */
-    public AbstractProjectManagementMacro(String name, String description, ContentDescriptor descriptor,
-        Class<?> clazz)
+    public AbstractProjectManagementMacro(String name, String description, ContentDescriptor descriptor, Class<?> clazz)
     {
         super(name, description, descriptor, clazz);
     }
@@ -90,17 +89,12 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
      * @throws MacroExecutionException if something went bad.
      */
     @Override
-    public List<Block> execute(T parameters, String content,
-        MacroTransformationContext context) throws MacroExecutionException
+    public List<Block> execute(T parameters, String content, MacroTransformationContext context)
+        throws MacroExecutionException
     {
         WorkItemsDisplayer displayer = parameters.getWorkItemsDisplayer();
         parameters.setSource("projectmanagement");
         processParameters(parameters);
-        String newContent = content;
-        if (parameters.getFilters() != null && !parameters.getFilters().isEmpty()) {
-            newContent = parameters.getFilters();
-            parameters.setFilters("");
-        }
         try {
             String displayerId = displayer.name();
             if (WorkItemsDisplayer.liveDataCards.equals(displayer) || WorkItemsDisplayer.liveData.equals(displayer)) {
@@ -112,8 +106,8 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
                 throw new MacroExecutionException(
                     String.format("Macro displayer [%s] is standalone but is being used inline.", displayerId));
             }
-            return asyncExecutor.execute(displayerMacro, parameters, newContent, context,
-                getAsyncParametersProcessor(), isAsync(parameters));
+            return asyncExecutor.execute(displayerMacro, parameters, content, context, getAsyncParametersProcessor(),
+                isAsync(parameters));
         } catch (ComponentLookupException e) {
             throw new MacroExecutionException(String.format("Could not find the displayer [%s].", displayer.name()), e);
         } catch (JobException | RenderingException e) {
@@ -128,15 +122,27 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
      */
     public abstract void processParameters(T parameters);
 
+    /**
+     * This method offers the possibility to update the parameters right before the executing the displayer in the async
+     * thread. The updated parameters will be passed down to the displayer macro.
+     *
+     * @param parameters the parameters of the currently executing macro. Updating this will affect how the macro is
+     *     rendered.
+     * @since 1.3.0
+     */
+    public abstract void asyncProcessParameters(T parameters);
+
     protected boolean isAsync(T parameters)
     {
         return !WorkItemsDisplayer.liveData.equals(parameters.getWorkItemsDisplayer())
             && !WorkItemsDisplayer.liveDataCards.equals(parameters.getWorkItemsDisplayer());
     }
 
-    protected Consumer<ProjectManagementAsyncRenderer> getAsyncParametersProcessor()
+    protected Consumer<ProjectManagementAsyncMacroParams> getAsyncParametersProcessor()
     {
-        return null;
+        return (params -> {
+            asyncProcessParameters((T) params);
+        });
     }
 
     protected void addToSourceParams(T parameters, String key, String value)
@@ -149,13 +155,8 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
             parameters.setSourceParameters(String.format("%s=%s", key, value));
         } else {
             parameters.setSourceParameters(
-                String.format(
-                    "%s&%s=%s",
-                    sourceParameters,
-                    URLEncoder.encode(key, StandardCharsets.UTF_8),
-                    URLEncoder.encode(value, StandardCharsets.UTF_8)
-                )
-            );
+                String.format("%s&%s=%s", sourceParameters, URLEncoder.encode(key, StandardCharsets.UTF_8),
+                    URLEncoder.encode(value, StandardCharsets.UTF_8)));
         }
     }
 }

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/AbstractProjectManagementMacro.java
@@ -132,7 +132,17 @@ public abstract class AbstractProjectManagementMacro<T extends ProjectManagement
      */
     public abstract void asyncProcessParameters(T parameters);
 
-    protected boolean isAsync(T parameters)
+    /**
+     * Denotes whether this macro, given it's parameters (mainly the displayer), should be rendered asynchronously or
+     * not. Some displayers might have their own async rendering handlers which will make our async rendering redundant
+     * i.e. the livedata displayers. By default, this method returns false in the case of the livedata displayers and
+     * true otherwise.
+     *
+     * @param parameters the parameters of the currently executing macro.
+     * @return true if the rendering should be done on a separate thread. false otherwise.
+     * @since 1.3.0
+     */
+    public boolean isAsync(T parameters)
     {
         return !WorkItemsDisplayer.liveData.equals(parameters.getWorkItemsDisplayer())
             && !WorkItemsDisplayer.liveDataCards.equals(parameters.getWorkItemsDisplayer());

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncExecutor.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncExecutor.java
@@ -23,8 +23,8 @@ package com.xwiki.projectmanagement.internal.macro;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -65,21 +65,25 @@ public class ProjectManagementAsyncExecutor
      * @param parameters the parameters of the macro.
      * @param content the content of the macro.
      * @param context the macro transformation context.
+     * @param paramsConsumer consumes the async renderer and can modify the parameters and content of the macro
+     *     before execution. i.e. make another api call in the async context.
+     * @param forcePlaceholder denotes whether to force the placeholder or nah.
      * @return the placeholder blocks that will be asynchronously populated.
      * @throws RenderingException if some exception was thrown during the rendering of the placeholder.
      * @throws JobException if some exception was thrown during the execution of the render job. This should not
      *     happen as we always render the placeholder.
      */
     public List<Block> execute(Macro<ProjectManagementAsyncMacroParams> displayerMacro,
-        ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context)
+        ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context,
+        Consumer<ProjectManagementAsyncRenderer> paramsConsumer, boolean forcePlaceholder)
         throws RenderingException, JobException
     {
 
         try {
-            AsyncRendererConfiguration configuration = getAsyncRendererConfiguration();
+            AsyncRendererConfiguration configuration = getAsyncRendererConfiguration(forcePlaceholder);
             ProjectManagementAsyncRenderer asyncRenderer =
                 componentManager.getInstance(ProjectManagementAsyncRenderer.class);
-            asyncRenderer.initialize(displayerMacro, parameters, content, context);
+            asyncRenderer.initialize(displayerMacro, parameters, content, context, paramsConsumer);
             Block result = executor.execute(asyncRenderer, configuration);
             return result instanceof CompositeBlock ? result.getChildren() : Collections.singletonList(result);
         } catch (ComponentLookupException e) {
@@ -88,8 +92,7 @@ public class ProjectManagementAsyncExecutor
         }
     }
 
-    @Nonnull
-    private static AsyncRendererConfiguration getAsyncRendererConfiguration()
+    private AsyncRendererConfiguration getAsyncRendererConfiguration(boolean forcePlaceholder)
     {
         AsyncRendererConfiguration configuration = new AsyncRendererConfiguration();
 
@@ -98,7 +101,7 @@ public class ProjectManagementAsyncExecutor
             Set.of(XWikiContextContextStore.PROP_USER, XWikiContextContextStore.PROP_WIKI,
                 XWikiContextContextStore.PROP_ACTION, XWikiContextContextStore.PROP_LOCALE));
         // We always want the results to be displayed async, since we make calls to other servers.
-        configuration.setPlaceHolderForced(true);
+        configuration.setPlaceHolderForced(forcePlaceholder);
         return configuration;
     }
 }

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncExecutor.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncExecutor.java
@@ -75,7 +75,7 @@ public class ProjectManagementAsyncExecutor
      */
     public List<Block> execute(Macro<ProjectManagementAsyncMacroParams> displayerMacro,
         ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context,
-        Consumer<ProjectManagementAsyncRenderer> paramsConsumer, boolean forcePlaceholder)
+        Consumer<ProjectManagementAsyncMacroParams> paramsConsumer, boolean forcePlaceholder)
         throws RenderingException, JobException
     {
 

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncRenderer.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncRenderer.java
@@ -21,6 +21,7 @@ package com.xwiki.projectmanagement.internal.macro;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.RenderingException;
@@ -59,6 +60,8 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
 
     private boolean inline;
 
+    private Consumer<ProjectManagementAsyncRenderer> paramsConsumer;
+
     /**
      * Initialize the async renderer with the required parameters for a project management displayer to function
      * properly.
@@ -68,9 +71,11 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
      * @param parameters the parameters passed to the displayer macro.
      * @param content the content passed to the displayer macro.
      * @param context the macro transformation context that will be taken in consideration by the executed macro.
+     * @param paramsConsumer
      */
     public void initialize(Macro<ProjectManagementAsyncMacroParams> displayer,
-        ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context)
+        ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context,
+        Consumer<ProjectManagementAsyncRenderer> paramsConsumer)
     {
         workItemsDisplayer = displayer;
         this.parameters = parameters;
@@ -78,6 +83,7 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
         this.transformationContext = context.clone();
         this.inline = this.transformationContext.isInline();
         this.targetSyntax = context.getTransformationContext().getTargetSyntax();
+        this.paramsConsumer = paramsConsumer;
 
         // I'm assuming that the id should be deterministic only if we are interested in caching the result. Since we
         // shouldn't cache the results coming from OpenProject, we can generate a random uuid.
@@ -88,6 +94,9 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
     protected Block execute(boolean async, boolean cached) throws RenderingException
     {
         try {
+            if (this.paramsConsumer != null) {
+                this.paramsConsumer.accept(this);
+            }
             List<Block> result = workItemsDisplayer.execute(this.parameters, this.content, this.transformationContext);
             if (this.transformationContext.getCurrentMacroBlock() != null) {
                 result = List.of(wrapInMacroMarker(this.transformationContext.getCurrentMacroBlock(), result));
@@ -96,6 +105,26 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
         } catch (MacroExecutionException e) {
             throw new RenderingException("Failed to render asynchronously the work items displayer [{}].", e);
         }
+    }
+
+    /**
+     * @param content set the content that will be passed to the executing macro. This should be called before
+     *     {@link #execute(boolean, boolean)}.
+     * @since 1.3.0
+     */
+    public void setMacroContent(String content)
+    {
+        this.content = content;
+    }
+
+    /**
+     * @return the reference to the stored macro parameters that will be passed during the async rendering. Can be
+     *     modified before {@link #execute(boolean, boolean)}.
+     * @since 1.3.0
+     */
+    public ProjectManagementAsyncMacroParams getParameters()
+    {
+        return this.parameters;
     }
 
     @Override

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncRenderer.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncRenderer.java
@@ -60,7 +60,7 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
 
     private boolean inline;
 
-    private Consumer<ProjectManagementAsyncRenderer> paramsConsumer;
+    private Consumer<ProjectManagementAsyncMacroParams> paramsConsumer;
 
     /**
      * Initialize the async renderer with the required parameters for a project management displayer to function
@@ -75,7 +75,7 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
      */
     public void initialize(Macro<ProjectManagementAsyncMacroParams> displayer,
         ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context,
-        Consumer<ProjectManagementAsyncRenderer> paramsConsumer)
+        Consumer<ProjectManagementAsyncMacroParams> paramsConsumer)
     {
         workItemsDisplayer = displayer;
         this.parameters = parameters;
@@ -95,7 +95,7 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
     {
         try {
             if (this.paramsConsumer != null) {
-                this.paramsConsumer.accept(this);
+                this.paramsConsumer.accept(this.parameters);
             }
             List<Block> result = workItemsDisplayer.execute(this.parameters, this.content, this.transformationContext);
             if (this.transformationContext.getCurrentMacroBlock() != null) {

--- a/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncRenderer.java
+++ b/project-management-macro/src/main/java/com/xwiki/projectmanagement/internal/macro/ProjectManagementAsyncRenderer.java
@@ -71,7 +71,8 @@ public class ProjectManagementAsyncRenderer extends AbstractBlockAsyncRenderer
      * @param parameters the parameters passed to the displayer macro.
      * @param content the content passed to the displayer macro.
      * @param context the macro transformation context that will be taken in consideration by the executed macro.
-     * @param paramsConsumer
+     * @param paramsConsumer a consumer for the parameters that will be passed to the executing displayer macro.
+     *     This can modify the parameters in order to change the bahaviour of the displayers.
      */
     public void initialize(Macro<ProjectManagementAsyncMacroParams> displayer,
         ProjectManagementAsyncMacroParams parameters, String content, MacroTransformationContext context,

--- a/project-management-macro/src/main/resources/META-INF/components.txt
+++ b/project-management-macro/src/main/resources/META-INF/components.txt
@@ -4,6 +4,7 @@ com.xwiki.projectmanagement.internal.rest.DefaultChartDisplayerResource
 com.xwiki.projectmanagement.internal.chart.displayer.BarChartDisplayer
 com.xwiki.projectmanagement.internal.chart.displayer.PieChartDisplayer
 com.xwiki.projectmanagement.internal.displayers.WorkItemsSingleDisplayer
+com.xwiki.projectmanagement.internal.displayers.WorkItemLivedataDisplayer
 com.xwiki.projectmanagement.internal.displayers.WorkItemInlineDisplayer
 com.xwiki.projectmanagement.internal.macro.ProjectManagementAsyncExecutor
 com.xwiki.projectmanagement.internal.macro.ProjectManagementAsyncRenderer

--- a/project-management-macro/src/test/java/com/xwiki/projectmanagement/AbstractProjectManagementMacroTest.java
+++ b/project-management-macro/src/test/java/com/xwiki/projectmanagement/AbstractProjectManagementMacroTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
-import org.xwiki.rendering.async.internal.block.BlockAsyncRendererExecutor;
+import org.xwiki.job.JobException;
+import org.xwiki.rendering.RenderingException;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.macro.MacroExecutionException;
@@ -42,6 +43,7 @@ import com.xwiki.projectmanagement.macro.ProjectManagementMacroParameters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -63,9 +65,6 @@ public class AbstractProjectManagementMacroTest
     private ComponentManager componentManager;
 
     @MockComponent
-    private BlockAsyncRendererExecutor executor;
-
-    @MockComponent
     private ProjectManagementAsyncExecutor asyncExecutor;
 
     @Mock
@@ -75,17 +74,19 @@ public class AbstractProjectManagementMacroTest
     private Macro<ProjectManagementAsyncMacroParams> displayerMacro;
 
     @Test
-    void executeMacroWithDefaultValuesTest() throws MacroExecutionException, ComponentLookupException
+    void executeMacroWithDefaultValuesTest()
+        throws MacroExecutionException, ComponentLookupException, JobException, RenderingException
     {
         ProjectManagementMacroParameters params = new ProjectManagementMacroParameters();
 
-        when(componentManager.getInstance(Macro.class, "liveData")).thenReturn(displayerMacro);
+        when(componentManager.getInstance(Macro.class, "proj-manag-liveData")).thenReturn(displayerMacro);
         abstractMacro.execute(params, "", macroTransformationContext);
 
         assertEquals("projectmanagement", params.getSource());
         assertEquals("smth=smth2&smth3=smth4", params.getSourceParameters());
 
-        verify(displayerMacro).execute(params, "", macroTransformationContext);
+        // Gets executed in the async renderer.
+        verify(asyncExecutor).execute(eq(displayerMacro), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -99,6 +100,6 @@ public class AbstractProjectManagementMacroTest
         List<Block> result = abstractMacro.execute(params, "", macroTransformationContext);
 
         // Gets executed in the async renderer.
-        verify(asyncExecutor).execute(eq(displayerMacro), any(), any(), any());
+        verify(asyncExecutor).execute(eq(displayerMacro), any(), any(), any(), any(), anyBoolean());
     }
 }

--- a/project-management-macro/src/test/java/com/xwiki/projectmanagement/internal/TestProjManagementMacro.java
+++ b/project-management-macro/src/test/java/com/xwiki/projectmanagement/internal/TestProjManagementMacro.java
@@ -48,4 +48,9 @@ public class TestProjManagementMacro extends AbstractProjectManagementMacro<Proj
         addToSourceParams(parameters, "smth", "smth2");
         addToSourceParams(parameters, "smth3", "smth4");
     }
+
+    @Override
+    public void asyncProcessParameters(ProjectManagementMacroParameters parameters)
+    {
+    }
 }

--- a/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/AsyncMacroCallResource.java
+++ b/project-management-openproject/project-management-openproject-api/src/main/java/com/xwiki/projectmanagement/openproject/internal/rest/AsyncMacroCallResource.java
@@ -146,7 +146,7 @@ public class AsyncMacroCallResource extends XWikiResource
         String content = jsonMapper.writeValueAsString(liveDataConfiguration);
 
         MacroTransformationContext context = new MacroTransformationContext();
-        asyncRenderer.initialize(displayerMacro, parameters, content, context);
+        asyncRenderer.initialize(displayerMacro, parameters, content, context, null);
         return asyncRenderer;
     }
 }

--- a/project-management-openproject/project-management-openproject-macro/src/main/java/com/xwiki/projectmanagement/openproject/internal/AbstractOpenProjectDirectMacro.java
+++ b/project-management-openproject/project-management-openproject-macro/src/main/java/com/xwiki/projectmanagement/openproject/internal/AbstractOpenProjectDirectMacro.java
@@ -120,7 +120,7 @@ public abstract class AbstractOpenProjectDirectMacro<P extends OpenProjectInstan
                 {
                     return executeInternal(parameters, content, context, apiClient, instanceToUse);
                 }
-            }, parameters, content, context);
+            }, parameters, content, context, null, true);
         } catch (RenderingException | JobException e) {
             throw new MacroExecutionException("Failed to render the macro asynchronously.", e);
         }

--- a/project-management-openproject/project-management-openproject-macro/src/main/java/com/xwiki/projectmanagement/openproject/internal/macro/OpenProjectMacro.java
+++ b/project-management-openproject/project-management-openproject-macro/src/main/java/com/xwiki/projectmanagement/openproject/internal/macro/OpenProjectMacro.java
@@ -111,6 +111,12 @@ public class OpenProjectMacro extends AbstractProjectManagementMacro<OpenProject
     }
 
     @Override
+    public void asyncProcessParameters(OpenProjectMacroParameters parameters)
+    {
+        // Update any parameters in the async context.
+    }
+
+    @Override
     public List<Block> execute(OpenProjectMacroParameters parameters, String content,
         MacroTransformationContext context) throws MacroExecutionException
     {


### PR DESCRIPTION
Refactored the code:
* Create a wrapping liveData macro in order to move the livedata logic from the AbstractProjManagMacro

Added new behaviour:
* Added method  `AbstractProjManagMacro#isAsync(params)` to allow the implementer to decide when to render the macro async
* Added method  `AbstractProjManagMacro#asyncProcessParams(params)` to allow the implementer to update the parameters in the async context if needed
* Allow the async executor and renderer to run custom logic before executing the displayer macro